### PR TITLE
Add Lease Timeout Detection

### DIFF
--- a/src/main/java/in/riido/locksmith/DistributedLock.java
+++ b/src/main/java/in/riido/locksmith/DistributedLock.java
@@ -129,4 +129,22 @@ public @interface DistributedLock {
    * @return the skip behavior, defaults to THROW_EXCEPTION
    */
   SkipBehavior onSkip() default SkipBehavior.THROW_EXCEPTION;
+
+  /**
+   * Defines the behavior when method execution time exceeds the configured lease duration.
+   *
+   * <p>When a method runs longer than its lock's lease time, the lock may expire while the method
+   * is still executing. This can lead to concurrent access by other instances. This parameter
+   * configures how to handle detection of such scenarios after method completion.
+   *
+   * <ul>
+   *   <li>{@link LeaseExpirationBehavior#LOG_WARNING} (default): Log a warning message
+   *   <li>{@link LeaseExpirationBehavior#THROW_EXCEPTION}: Throw {@link
+   *       in.riido.locksmith.exception.LeaseExpiredException}
+   *   <li>{@link LeaseExpirationBehavior#IGNORE}: Silently ignore
+   * </ul>
+   *
+   * @return the lease expiration behavior, defaults to LOG_WARNING
+   */
+  LeaseExpirationBehavior onLeaseExpired() default LeaseExpirationBehavior.LOG_WARNING;
 }

--- a/src/main/java/in/riido/locksmith/LeaseExpirationBehavior.java
+++ b/src/main/java/in/riido/locksmith/LeaseExpirationBehavior.java
@@ -1,0 +1,33 @@
+package in.riido.locksmith;
+
+/**
+ * Defines the behavior when a method's execution time exceeds the configured lease duration.
+ *
+ * <p>When a method runs longer than its lock's lease time, the lock may expire while the method is
+ * still executing. This can lead to concurrent access by multiple instances. This enum configures
+ * how to handle detection of such scenarios after method completion.
+ *
+ * @author Garvit Joshi
+ * @since 1.2.0
+ */
+public enum LeaseExpirationBehavior {
+
+  /**
+   * Log a warning when execution time exceeds lease duration. This is the default behavior,
+   * providing visibility into potential issues without disrupting the application.
+   */
+  LOG_WARNING,
+
+  /**
+   * Throw a {@link in.riido.locksmith.exception.LeaseExpiredException} after the method completes
+   * if execution time exceeded lease duration. Use this for strict enforcement where such
+   * violations should be treated as errors.
+   */
+  THROW_EXCEPTION,
+
+  /**
+   * Silently ignore when execution time exceeds lease duration. Use this only when you're certain
+   * the extended execution is acceptable and won't cause issues.
+   */
+  IGNORE
+}

--- a/src/main/java/in/riido/locksmith/exception/LeaseExpiredException.java
+++ b/src/main/java/in/riido/locksmith/exception/LeaseExpiredException.java
@@ -1,0 +1,77 @@
+package in.riido.locksmith.exception;
+
+/**
+ * Exception thrown when a method's execution time exceeds the configured lease duration.
+ *
+ * <p>This exception is thrown after the method completes when the configured behavior is {@link
+ * in.riido.locksmith.LeaseExpirationBehavior#THROW_EXCEPTION}. It indicates that the lock may have
+ * expired during execution, potentially allowing concurrent access by other instances.
+ *
+ * @author Garvit Joshi
+ * @since 1.2.0
+ */
+public class LeaseExpiredException extends RuntimeException {
+
+  private final String lockKey;
+  private final String methodName;
+  private final long leaseTimeMs;
+  private final long executionTimeMs;
+
+  /**
+   * Constructs a new LeaseExpiredException.
+   *
+   * @param lockKey the lock key that expired
+   * @param methodName the method that exceeded lease time
+   * @param leaseTimeMs the configured lease time in milliseconds
+   * @param executionTimeMs the actual execution time in milliseconds
+   */
+  public LeaseExpiredException(
+      String lockKey, String methodName, long leaseTimeMs, long executionTimeMs) {
+    super(
+        String.format(
+            "Lock [%s] lease expired during execution of [%s]. "
+                + "Lease time: %dms, Execution time: %dms. "
+                + "The lock may have been acquired by another instance during execution.",
+            lockKey, methodName, leaseTimeMs, executionTimeMs));
+    this.lockKey = lockKey;
+    this.methodName = methodName;
+    this.leaseTimeMs = leaseTimeMs;
+    this.executionTimeMs = executionTimeMs;
+  }
+
+  /**
+   * Returns the lock key that expired.
+   *
+   * @return the lock key
+   */
+  public String getLockKey() {
+    return lockKey;
+  }
+
+  /**
+   * Returns the method name that exceeded lease time.
+   *
+   * @return the method name
+   */
+  public String getMethodName() {
+    return methodName;
+  }
+
+  /**
+   * Returns the configured lease time in milliseconds.
+   *
+   * @return the lease time in milliseconds
+   */
+  public long getLeaseTimeMs() {
+    return leaseTimeMs;
+  }
+
+  /**
+   * Returns the actual execution time in milliseconds.
+   *
+   * @return the execution time in milliseconds
+   */
+  public long getExecutionTimeMs() {
+    return executionTimeMs;
+  }
+}


### PR DESCRIPTION
## Summary
- Add `LeaseExpirationBehavior` enum with LOG_WARNING, THROW_EXCEPTION, and IGNORE options
- Add `LeaseExpiredException` for strict enforcement when execution exceeds lease time
- Add `onLeaseExpired` parameter to `@DistributedLock` annotation (default: LOG_WARNING)
- Update `DistributedLockAspect` to track execution time and check against configured lease
- Add 6 new tests for all lease expiration behaviors
- Update README with documentation and examples

## Problem
When a method runs longer than its lock's lease time, the lock may expire while the method is still executing. This can lead to concurrent access by other instances, potentially causing data corruption or race conditions.

## Solution
Detect execution time exceeding lease duration and handle according to configuration:
- **LOG_WARNING** (default): Log a warning for visibility without disrupting the application
- **THROW_EXCEPTION**: Throw `LeaseExpiredException` for strict enforcement
- **IGNORE**: Silently ignore (for best-effort scenarios)

## Usage

```java
@DistributedLock(
    key = "critical-task",
    leaseTime = "10m",
    onLeaseExpired = LeaseExpirationBehavior.THROW_EXCEPTION
)
public void criticalTask() { }
```

## Test plan
- [x] All existing tests pass
- [x] Test execution within lease time (no warning/exception)
- [x] Test THROW_EXCEPTION behavior when execution exceeds lease
- [x] Test IGNORE behavior when execution exceeds lease
- [x] Test LOG_WARNING behavior when execution exceeds lease
- [x] Test lock is still released after LeaseExpiredException
- [x] Test LeaseExpiredException contains correct information

Closes #4