### PR TITLE
Add wrapper type support to ReturnDefaultHandler

### DIFF
--- a/src/main/java/in/riido/locksmith/handler/ReturnDefaultHandler.java
+++ b/src/main/java/in/riido/locksmith/handler/ReturnDefaultHandler.java
@@ -4,10 +4,11 @@ package in.riido.locksmith.handler;
  * A {@link LockSkipHandler} that returns default values when a lock cannot be acquired.
  *
  * <ul>
- *   <li>Returns {@code null} for object types and {@code void}
- *   <li>Returns {@code false} for {@code boolean}
- *   <li>Returns {@code 0} for numeric primitives ({@code int}, {@code long}, {@code double}, etc.)
- *   <li>Returns {@code '\u0000'} for {@code char}
+ *   <li>Returns {@code null} for object types and {@code void}/{@code Void}
+ *   <li>Returns {@code false} for {@code boolean}/{@code Boolean}
+ *   <li>Returns {@code 0} for numeric primitives and their wrapper types ({@code int}/{@code
+ *       Integer}, {@code long}/{@code Long}, {@code double}/{@code Double}, etc.)
+ *   <li>Returns {@code '\u0000'} for {@code char}/{@code Character}
  * </ul>
  *
  * @author Garvit Joshi
@@ -21,15 +22,15 @@ public class ReturnDefaultHandler implements LockSkipHandler {
   @Override
   public Object handle(LockContext context) {
     Class<?> returnType = context.returnType();
-    if (returnType == void.class) return null;
-    if (returnType == boolean.class) return false;
-    if (returnType == int.class) return 0;
-    if (returnType == long.class) return 0L;
-    if (returnType == double.class) return 0.0d;
-    if (returnType == float.class) return 0.0f;
-    if (returnType == byte.class) return (byte) 0;
-    if (returnType == short.class) return (short) 0;
-    if (returnType == char.class) return '\u0000';
+    if (returnType == void.class || returnType == Void.class) return null;
+    if (returnType == boolean.class || returnType == Boolean.class) return false;
+    if (returnType == int.class || returnType == Integer.class) return 0;
+    if (returnType == long.class || returnType == Long.class) return 0L;
+    if (returnType == double.class || returnType == Double.class) return 0.0d;
+    if (returnType == float.class || returnType == Float.class) return 0.0f;
+    if (returnType == byte.class || returnType == Byte.class) return (byte) 0;
+    if (returnType == short.class || returnType == Short.class) return (short) 0;
+    if (returnType == char.class || returnType == Character.class) return '\u0000';
     return null;
   }
 }

--- a/src/test/java/in/riido/locksmith/aspect/DistributedLockAspectTest.java
+++ b/src/test/java/in/riido/locksmith/aspect/DistributedLockAspectTest.java
@@ -737,8 +737,8 @@ class DistributedLockAspectTest {
     }
 
     @Test
-    @DisplayName("Should return null for Boolean wrapper with RETURN_DEFAULT")
-    void shouldReturnNullForBooleanWrapper() throws Throwable {
+    @DisplayName("Should return false for Boolean wrapper with RETURN_DEFAULT")
+    void shouldReturnFalseForBooleanWrapper() throws Throwable {
       when(methodSignature.getReturnType()).thenReturn(Boolean.class);
       setupAnnotation(
           "test-lock", LockAcquisitionMode.SKIP_IMMEDIATELY, "", "", ReturnDefaultHandler.class);
@@ -747,7 +747,105 @@ class DistributedLockAspectTest {
 
       Object result = aspect.handleDistributedLock(joinPoint);
 
-      assertNull(result);
+      assertEquals(false, result);
+    }
+
+    @Test
+    @DisplayName("Should return 0 for Integer wrapper with RETURN_DEFAULT")
+    void shouldReturnZeroForIntegerWrapper() throws Throwable {
+      when(methodSignature.getReturnType()).thenReturn(Integer.class);
+      setupAnnotation(
+          "test-lock", LockAcquisitionMode.SKIP_IMMEDIATELY, "", "", ReturnDefaultHandler.class);
+      when(redissonClient.getLock("lock:test-lock")).thenReturn(lock);
+      when(lock.tryLock(0, 600, TimeUnit.SECONDS)).thenReturn(false);
+
+      Object result = aspect.handleDistributedLock(joinPoint);
+
+      assertEquals(0, result);
+    }
+
+    @Test
+    @DisplayName("Should return 0L for Long wrapper with RETURN_DEFAULT")
+    void shouldReturnZeroForLongWrapper() throws Throwable {
+      when(methodSignature.getReturnType()).thenReturn(Long.class);
+      setupAnnotation(
+          "test-lock", LockAcquisitionMode.SKIP_IMMEDIATELY, "", "", ReturnDefaultHandler.class);
+      when(redissonClient.getLock("lock:test-lock")).thenReturn(lock);
+      when(lock.tryLock(0, 600, TimeUnit.SECONDS)).thenReturn(false);
+
+      Object result = aspect.handleDistributedLock(joinPoint);
+
+      assertEquals(0L, result);
+    }
+
+    @Test
+    @DisplayName("Should return 0.0d for Double wrapper with RETURN_DEFAULT")
+    void shouldReturnZeroForDoubleWrapper() throws Throwable {
+      when(methodSignature.getReturnType()).thenReturn(Double.class);
+      setupAnnotation(
+          "test-lock", LockAcquisitionMode.SKIP_IMMEDIATELY, "", "", ReturnDefaultHandler.class);
+      when(redissonClient.getLock("lock:test-lock")).thenReturn(lock);
+      when(lock.tryLock(0, 600, TimeUnit.SECONDS)).thenReturn(false);
+
+      Object result = aspect.handleDistributedLock(joinPoint);
+
+      assertEquals(0.0d, result);
+    }
+
+    @Test
+    @DisplayName("Should return 0.0f for Float wrapper with RETURN_DEFAULT")
+    void shouldReturnZeroForFloatWrapper() throws Throwable {
+      when(methodSignature.getReturnType()).thenReturn(Float.class);
+      setupAnnotation(
+          "test-lock", LockAcquisitionMode.SKIP_IMMEDIATELY, "", "", ReturnDefaultHandler.class);
+      when(redissonClient.getLock("lock:test-lock")).thenReturn(lock);
+      when(lock.tryLock(0, 600, TimeUnit.SECONDS)).thenReturn(false);
+
+      Object result = aspect.handleDistributedLock(joinPoint);
+
+      assertEquals(0.0f, result);
+    }
+
+    @Test
+    @DisplayName("Should return 0 for Byte wrapper with RETURN_DEFAULT")
+    void shouldReturnZeroForByteWrapper() throws Throwable {
+      when(methodSignature.getReturnType()).thenReturn(Byte.class);
+      setupAnnotation(
+          "test-lock", LockAcquisitionMode.SKIP_IMMEDIATELY, "", "", ReturnDefaultHandler.class);
+      when(redissonClient.getLock("lock:test-lock")).thenReturn(lock);
+      when(lock.tryLock(0, 600, TimeUnit.SECONDS)).thenReturn(false);
+
+      Object result = aspect.handleDistributedLock(joinPoint);
+
+      assertEquals((byte) 0, result);
+    }
+
+    @Test
+    @DisplayName("Should return 0 for Short wrapper with RETURN_DEFAULT")
+    void shouldReturnZeroForShortWrapper() throws Throwable {
+      when(methodSignature.getReturnType()).thenReturn(Short.class);
+      setupAnnotation(
+          "test-lock", LockAcquisitionMode.SKIP_IMMEDIATELY, "", "", ReturnDefaultHandler.class);
+      when(redissonClient.getLock("lock:test-lock")).thenReturn(lock);
+      when(lock.tryLock(0, 600, TimeUnit.SECONDS)).thenReturn(false);
+
+      Object result = aspect.handleDistributedLock(joinPoint);
+
+      assertEquals((short) 0, result);
+    }
+
+    @Test
+    @DisplayName("Should return null char for Character wrapper with RETURN_DEFAULT")
+    void shouldReturnNullCharForCharacterWrapper() throws Throwable {
+      when(methodSignature.getReturnType()).thenReturn(Character.class);
+      setupAnnotation(
+          "test-lock", LockAcquisitionMode.SKIP_IMMEDIATELY, "", "", ReturnDefaultHandler.class);
+      when(redissonClient.getLock("lock:test-lock")).thenReturn(lock);
+      when(lock.tryLock(0, 600, TimeUnit.SECONDS)).thenReturn(false);
+
+      Object result = aspect.handleDistributedLock(joinPoint);
+
+      assertEquals('\u0000', result);
     }
   }
 


### PR DESCRIPTION
ReturnDefaultHandler now returns default values for wrapper types (Boolean, Integer, Long, etc.) instead of null, matching the behavior of their primitive counterparts.

Fixes #14