### PR TITLE
Add input validation to LockContext record

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Locksmith
 
+[![Maven Central](https://img.shields.io/maven-central/v/in.riido/locksmith-spring-boot-starter)](https://central.sonatype.com/artifact/in.riido/locksmith-spring-boot-starter)
+
 A Spring Boot starter for Redis-based distributed locking using annotations. Ensures only one instance across all servers executes a method at a time.
 
 ## Features
@@ -22,7 +24,7 @@ A Spring Boot starter for Redis-based distributed locking using annotations. Ens
 
 ## Installation
 
-Add the dependency to your `pom.xml`:
+Add the dependency to your `pom.xml` (available on [Maven Central](https://central.sonatype.com/artifact/in.riido/locksmith-spring-boot-starter)):
 
 ```xml
 <dependency>

--- a/src/main/java/in/riido/locksmith/handler/LockContext.java
+++ b/src/main/java/in/riido/locksmith/handler/LockContext.java
@@ -1,6 +1,7 @@
 package in.riido.locksmith.handler;
 
 import java.lang.reflect.Method;
+import java.util.Objects;
 
 /**
  * Provides contextual information about a lock acquisition attempt.
@@ -17,4 +18,14 @@ import java.lang.reflect.Method;
  * @since 1.2.0
  */
 public record LockContext(
-    String lockKey, String methodName, Method method, Object[] args, Class<?> returnType) {}
+    String lockKey, String methodName, Method method, Object[] args, Class<?> returnType) {
+
+  /** Compact constructor that validates all parameters are non-null. */
+  public LockContext {
+    Objects.requireNonNull(lockKey, "lockKey must not be null");
+    Objects.requireNonNull(methodName, "methodName must not be null");
+    Objects.requireNonNull(method, "method must not be null");
+    Objects.requireNonNull(args, "args must not be null");
+    Objects.requireNonNull(returnType, "returnType must not be null");
+  }
+}

--- a/src/test/java/in/riido/locksmith/aspect/DistributedLockAspectTest.java
+++ b/src/test/java/in/riido/locksmith/aspect/DistributedLockAspectTest.java
@@ -51,6 +51,8 @@ class DistributedLockAspectTest {
     when(joinPoint.getSignature()).thenReturn(methodSignature);
     when(methodSignature.getDeclaringType()).thenReturn(TestClass.class);
     when(methodSignature.getName()).thenReturn("testMethod");
+    when(joinPoint.getArgs()).thenReturn(new Object[] {});
+    when(methodSignature.getReturnType()).thenReturn(void.class);
   }
 
   private void setupAnnotation(


### PR DESCRIPTION
## Summary
- Add compact constructor with `Objects.requireNonNull` validation for all fields in `LockContext` record
- Update test mocks to provide required `args` and `returnType` values
- Add Maven Central badge and link in README

Fixes #15