### PR TITLE
Remove isHeldByCurrentThread check for virtual thread compatibility

### DIFF
--- a/src/main/java/in/riido/locksmith/aspect/DistributedLockAspect.java
+++ b/src/main/java/in/riido/locksmith/aspect/DistributedLockAspect.java
@@ -194,11 +194,10 @@ public class DistributedLockAspect {
 
   private void releaseLock(RLock lock, String lockKey, String methodName) {
     try {
-      if (lock.isHeldByCurrentThread()) {
-        lock.unlock();
-        LOG.debug("Lock [{}] released for [{}]", lockKey, methodName);
-      }
+      lock.unlock();
+      LOG.debug("Lock [{}] released for [{}]", lockKey, methodName);
     } catch (IllegalMonitorStateException e) {
+      // Lock may have expired or been released due to virtual thread carrier thread changes
       LOG.warn(
           "Lock [{}] was already released (possibly expired) for [{}]: {}",
           lockKey,

--- a/src/test/java/in/riido/locksmith/aspect/DistributedLockAspectTest.java
+++ b/src/test/java/in/riido/locksmith/aspect/DistributedLockAspectTest.java
@@ -339,28 +339,12 @@ class DistributedLockAspectTest {
     }
 
     @Test
-    @DisplayName("Should not release lock if not held by current thread")
-    void shouldNotReleaseLockIfNotHeldByCurrentThread() throws Throwable {
-      setupAnnotation(
-          "test-lock", LockAcquisitionMode.SKIP_IMMEDIATELY, "", "", ThrowExceptionHandler.class);
-      when(redissonClient.getLock("lock:test-lock")).thenReturn(lock);
-      when(lock.tryLock(0, 600000, TimeUnit.MILLISECONDS)).thenReturn(true);
-      when(lock.isHeldByCurrentThread()).thenReturn(false);
-      when(joinPoint.proceed()).thenReturn("result");
-
-      aspect.handleDistributedLock(joinPoint);
-
-      verify(lock, never()).unlock();
-    }
-
-    @Test
     @DisplayName("Should handle IllegalMonitorStateException during unlock gracefully")
     void shouldHandleIllegalMonitorStateExceptionDuringUnlock() throws Throwable {
       setupAnnotation(
           "test-lock", LockAcquisitionMode.SKIP_IMMEDIATELY, "", "", ThrowExceptionHandler.class);
       when(redissonClient.getLock("lock:test-lock")).thenReturn(lock);
       when(lock.tryLock(0, 600000, TimeUnit.MILLISECONDS)).thenReturn(true);
-      when(lock.isHeldByCurrentThread()).thenReturn(true);
       when(joinPoint.proceed()).thenReturn("result");
       doThrow(new IllegalMonitorStateException("Lock expired")).when(lock).unlock();
 


### PR DESCRIPTION
## Summary

- Removes the `isHeldByCurrentThread()` check before unlocking
- Simply attempts to unlock and handles `IllegalMonitorStateException` gracefully
- Prevents potential lock leaks with Java 21+ virtual threads

## Problem

With Java 21+ virtual threads, `isHeldByCurrentThread()` may return `false` incorrectly when the carrier thread changes during blocking operations. This could cause the lock to not be released, holding it until lease expiration.

## Solution

Since `lockAcquired` already tracks successful acquisition, we can safely attempt to unlock without the pre-check. Any `IllegalMonitorStateException` (from expired locks) is caught and logged.

## Test plan

- [x] All 117 tests pass
- [x] Removed obsolete test that verified old behavior

Closes #22