### PR TITLE
feat: add LocksmithTemplate for programmatic lock and semaphore access

### DIFF
--- a/src/main/java/in/riido/locksmith/autoconfigure/LocksmithAutoConfiguration.java
+++ b/src/main/java/in/riido/locksmith/autoconfigure/LocksmithAutoConfiguration.java
@@ -2,6 +2,8 @@ package in.riido.locksmith.autoconfigure;
 
 import in.riido.locksmith.aspect.DistributedLockAspect;
 import in.riido.locksmith.aspect.DistributedSemaphoreAspect;
+import in.riido.locksmith.template.LocksmithLockTemplate;
+import in.riido.locksmith.template.LocksmithSemaphoreTemplate;
 import org.jspecify.annotations.NonNull;
 import org.redisson.api.RedissonClient;
 import org.slf4j.Logger;
@@ -105,5 +107,39 @@ public class LocksmithAutoConfiguration {
         redissonVersion,
         properties.semaphore());
     return new DistributedSemaphoreAspect(redissonClient, properties, applicationContext);
+  }
+
+  /**
+   * Creates the lock template bean for programmatic lock access.
+   *
+   * @param redissonClient the Redisson client (must be provided by the user)
+   * @param properties the locksmith configuration properties
+   * @return the configured LocksmithLockTemplate
+   * @since 2.1.0
+   */
+  @Bean
+  @ConditionalOnMissingBean
+  @NonNull
+  public LocksmithLockTemplate locksmithLockTemplate(
+      @NonNull RedissonClient redissonClient, @NonNull LocksmithProperties properties) {
+    LOG.info("Initializing locksmith lock template");
+    return new LocksmithLockTemplate(redissonClient, properties);
+  }
+
+  /**
+   * Creates the semaphore template bean for programmatic semaphore access.
+   *
+   * @param redissonClient the Redisson client (must be provided by the user)
+   * @param properties the locksmith configuration properties
+   * @return the configured LocksmithSemaphoreTemplate
+   * @since 2.1.0
+   */
+  @Bean
+  @ConditionalOnMissingBean
+  @NonNull
+  public LocksmithSemaphoreTemplate locksmithSemaphoreTemplate(
+      @NonNull RedissonClient redissonClient, @NonNull LocksmithProperties properties) {
+    LOG.info("Initializing locksmith semaphore template");
+    return new LocksmithSemaphoreTemplate(redissonClient, properties);
   }
 }

--- a/src/main/java/in/riido/locksmith/autoconfigure/LocksmithProperties.java
+++ b/src/main/java/in/riido/locksmith/autoconfigure/LocksmithProperties.java
@@ -2,7 +2,6 @@ package in.riido.locksmith.autoconfigure;
 
 import java.time.Duration;
 import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.Nullable;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
@@ -32,8 +31,8 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
  */
 @ConfigurationProperties(prefix = "locksmith")
 public record LocksmithProperties(
-    @NestedConfigurationProperty @Nullable LockProperties lock,
-    @NestedConfigurationProperty @Nullable SemaphoreProperties semaphore) {
+    @NestedConfigurationProperty @NonNull LockProperties lock,
+    @NestedConfigurationProperty @NonNull SemaphoreProperties semaphore) {
 
   /**
    * Compact constructor that applies default values for null inputs.
@@ -57,7 +56,7 @@ public record LocksmithProperties(
    */
   @NonNull
   public static LocksmithProperties defaults() {
-    return new LocksmithProperties(null, null);
+    return new LocksmithProperties(LockProperties.defaults(), SemaphoreProperties.defaults());
   }
 
   @Override
@@ -78,10 +77,10 @@ public record LocksmithProperties(
    *     resolution, lock type, timing, and acquisition status. Default: false.
    */
   public record LockProperties(
-      @Nullable Duration leaseTime,
-      @Nullable Duration waitTime,
-      @Nullable String keyPrefix,
-      @Nullable Boolean debug) {
+      @NonNull Duration leaseTime,
+      @NonNull Duration waitTime,
+      @NonNull String keyPrefix,
+      @NonNull Boolean debug) {
 
     /** Default lease time for locks. */
     public static final Duration DEFAULT_LEASE_TIME = Duration.ofMinutes(10);
@@ -125,7 +124,8 @@ public record LocksmithProperties(
      */
     @NonNull
     public static LockProperties defaults() {
-      return new LockProperties(null, null, null, null);
+      return new LockProperties(
+          DEFAULT_LEASE_TIME, DEFAULT_WAIT_TIME, DEFAULT_KEY_PREFIX, DEFAULT_DEBUG);
     }
 
     @Override
@@ -155,10 +155,10 @@ public record LocksmithProperties(
    *     resolution, permit acquisition, timing, and status. Default: false.
    */
   public record SemaphoreProperties(
-      @Nullable Duration leaseTime,
-      @Nullable Duration waitTime,
-      @Nullable String keyPrefix,
-      @Nullable Boolean debug) {
+      @NonNull Duration leaseTime,
+      @NonNull Duration waitTime,
+      @NonNull String keyPrefix,
+      @NonNull Boolean debug) {
 
     /** Default lease time for semaphores. */
     public static final Duration DEFAULT_LEASE_TIME = Duration.ofMinutes(5);
@@ -202,7 +202,8 @@ public record LocksmithProperties(
      */
     @NonNull
     public static SemaphoreProperties defaults() {
-      return new SemaphoreProperties(null, null, null, null);
+      return new SemaphoreProperties(
+          DEFAULT_LEASE_TIME, DEFAULT_WAIT_TIME, DEFAULT_KEY_PREFIX, DEFAULT_DEBUG);
     }
 
     @Override

--- a/src/main/java/in/riido/locksmith/template/LockCallback.java
+++ b/src/main/java/in/riido/locksmith/template/LockCallback.java
@@ -1,0 +1,36 @@
+package in.riido.locksmith.template;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Functional interface for code to be executed within a distributed lock.
+ *
+ * <p>This callback is used with {@link LocksmithLockTemplate#executeWithLock} to execute code while
+ * holding a distributed lock. The callback may throw any exception, which will be propagated to the
+ * caller after the lock is released.
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * String result = lockTemplate.executeWithLock("my-key", () -> {
+ *     // Code executed while holding the lock
+ *     return "result";
+ * });
+ * }</pre>
+ *
+ * @param <T> the type of result returned by the callback
+ * @author Garvit Joshi
+ * @since 2.1.0
+ * @see LocksmithLockTemplate
+ */
+@FunctionalInterface
+public interface LockCallback<T> {
+
+  /**
+   * Executes the callback logic while holding the distributed lock.
+   *
+   * @return the result of the execution, may be null
+   * @throws Exception if any error occurs during execution
+   */
+  @Nullable T execute() throws Exception;
+}

--- a/src/main/java/in/riido/locksmith/template/LocksmithLockTemplate.java
+++ b/src/main/java/in/riido/locksmith/template/LocksmithLockTemplate.java
@@ -1,0 +1,411 @@
+package in.riido.locksmith.template;
+
+import in.riido.locksmith.LockType;
+import in.riido.locksmith.autoconfigure.LocksmithProperties;
+import in.riido.locksmith.autoconfigure.LocksmithProperties.LockProperties;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Template class for programmatic distributed lock operations.
+ *
+ * <p>This class provides a programmatic API for distributed locks, complementing the
+ * annotation-based approach provided by {@link in.riido.locksmith.DistributedLock}. Use this when
+ * you need more control over lock acquisition and release, or when annotations are not suitable.
+ *
+ * <p>All methods apply the configured key prefix automatically. For example, if the key prefix is
+ * "lock:" and you call {@code tryLock("my-key")}, the actual Redis key will be "lock:my-key".
+ *
+ * <h2>Simple Usage</h2>
+ *
+ * <pre>{@code
+ * // Acquire and release
+ * if (lockTemplate.tryLock("my-key")) {
+ *     try {
+ *         // Critical section
+ *     } finally {
+ *         lockTemplate.unlock("my-key");
+ *     }
+ * }
+ *
+ * // Callback-based (recommended)
+ * String result = lockTemplate.executeWithLock("my-key", () -> {
+ *     return "executed";
+ * });
+ * }</pre>
+ *
+ * <h2>Builder for Complex Cases</h2>
+ *
+ * <pre>{@code
+ * // With custom timing and lock type
+ * boolean acquired = lockTemplate.forKey("my-key")
+ *     .waitTime(Duration.ofSeconds(5))
+ *     .leaseTime(Duration.ofMinutes(2))
+ *     .lockType(LockType.WRITE)
+ *     .tryLock();
+ *
+ * // With auto-renew
+ * String result = lockTemplate.forKey("my-key")
+ *     .autoRenew()
+ *     .execute(() -> {
+ *         // Long-running operation
+ *         return "done";
+ *     });
+ * }</pre>
+ *
+ * @author Garvit Joshi
+ * @since 2.1.0
+ * @see LockCallback
+ * @see LockOperationBuilder
+ * @see in.riido.locksmith.DistributedLock
+ */
+public class LocksmithLockTemplate {
+
+  private static final Logger LOG = LoggerFactory.getLogger(LocksmithLockTemplate.class);
+
+  private final RedissonClient redissonClient;
+  private final LockProperties lockProperties;
+
+  /**
+   * Constructs a new LocksmithLockTemplate.
+   *
+   * @param redissonClient the Redisson client for Redis operations
+   * @param properties the configuration properties
+   */
+  public LocksmithLockTemplate(
+      @NonNull RedissonClient redissonClient, @NonNull LocksmithProperties properties) {
+    this.redissonClient = redissonClient;
+    this.lockProperties = properties.lock();
+  }
+
+  // ========== Simple Methods ==========
+
+  /**
+   * Tries to acquire a reentrant lock immediately without waiting.
+   *
+   * <p>Uses the default lease time from configuration. For more control, use {@link
+   * #forKey(String)}.
+   *
+   * @param key the lock key (prefix will be applied automatically)
+   * @return true if the lock was acquired, false otherwise
+   */
+  public boolean tryLock(@NonNull String key) {
+    return doTryLock(key, Duration.ZERO, lockProperties.leaseTime(), LockType.REENTRANT);
+  }
+
+  /**
+   * Releases a reentrant lock.
+   *
+   * <p>For other lock types, use {@link #forKey(String)}.
+   *
+   * @param key the lock key (prefix will be applied automatically)
+   */
+  public void unlock(@NonNull String key) {
+    doUnlock(key, LockType.REENTRANT);
+  }
+
+  /**
+   * Checks if a reentrant lock is currently held by any thread/instance.
+   *
+   * <p>For other lock types, use {@link #forKey(String)}.
+   *
+   * @param key the lock key (prefix will be applied automatically)
+   * @return true if the lock is held by anyone, false otherwise
+   */
+  public boolean isLocked(@NonNull String key) {
+    return doIsLocked(key, LockType.REENTRANT);
+  }
+
+  /**
+   * Executes a callback while holding a reentrant lock.
+   *
+   * <p>Tries to acquire the lock immediately without waiting. Uses the default lease time from
+   * configuration. For more control, use {@link #forKey(String)}.
+   *
+   * @param <T> the type of result returned by the callback
+   * @param key the lock key (prefix will be applied automatically)
+   * @param callback the callback to execute while holding the lock
+   * @return the result of the callback, or null if the lock could not be acquired
+   * @throws Exception if the callback throws an exception
+   */
+  @Nullable
+  public <T> T executeWithLock(@NonNull String key, @NonNull LockCallback<T> callback)
+      throws Exception {
+    return doExecuteWithLock(
+        key, Duration.ZERO, lockProperties.leaseTime(), LockType.REENTRANT, callback);
+  }
+
+  // ========== Builder Entry Point ==========
+
+  /**
+   * Creates a builder for lock operations on the specified key.
+   *
+   * <p>Use the builder when you need to customize wait time, lease time, lock type, or enable
+   * auto-renew.
+   *
+   * <pre>{@code
+   * // Custom timing
+   * lockTemplate.forKey("my-key")
+   *     .waitTime(Duration.ofSeconds(5))
+   *     .leaseTime(Duration.ofMinutes(2))
+   *     .tryLock();
+   *
+   * // Auto-renew with write lock
+   * lockTemplate.forKey("my-key")
+   *     .lockType(LockType.WRITE)
+   *     .autoRenew()
+   *     .execute(() -> doWork());
+   * }</pre>
+   *
+   * @param key the lock key (prefix will be applied automatically)
+   * @return a builder for configuring and executing lock operations
+   */
+  @NonNull
+  public LockOperationBuilder forKey(@NonNull String key) {
+    return new LockOperationBuilder(key);
+  }
+
+  // ========== Internal Methods ==========
+
+  private boolean doTryLock(
+      @NonNull String key,
+      @NonNull Duration waitTime,
+      @NonNull Duration leaseTime,
+      @NonNull LockType lockType) {
+    String fullKey = lockProperties.keyPrefix() + key;
+    RLock lock = getLock(fullKey, lockType);
+
+    try {
+      boolean acquired =
+          lock.tryLock(waitTime.toMillis(), leaseTime.toMillis(), TimeUnit.MILLISECONDS);
+      if (acquired) {
+        LOG.debug("Lock [{}] acquired with type={}", fullKey, lockType);
+      } else {
+        LOG.debug("Failed to acquire lock [{}] with type={}", fullKey, lockType);
+      }
+      return acquired;
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      LOG.warn("Thread interrupted while waiting for lock [{}]", fullKey);
+      return false;
+    }
+  }
+
+  private void doUnlock(@NonNull String key, @NonNull LockType lockType) {
+    String fullKey = lockProperties.keyPrefix() + key;
+    RLock lock = getLock(fullKey, lockType);
+
+    try {
+      lock.unlock();
+      LOG.debug("Lock [{}] released with type={}", fullKey, lockType);
+    } catch (IllegalMonitorStateException e) {
+      LOG.warn(
+          "Failed to unlock [{}] - lock not held by current thread or already released: {}",
+          fullKey,
+          e.getMessage());
+    }
+  }
+
+  private boolean doIsLocked(@NonNull String key, @NonNull LockType lockType) {
+    String fullKey = lockProperties.keyPrefix() + key;
+    RLock lock = getLock(fullKey, lockType);
+    return lock.isLocked();
+  }
+
+  @Nullable
+  private <T> T doExecuteWithLock(
+      @NonNull String key,
+      @NonNull Duration waitTime,
+      @NonNull Duration leaseTime,
+      @NonNull LockType lockType,
+      @NonNull LockCallback<T> callback)
+      throws Exception {
+    String fullKey = lockProperties.keyPrefix() + key;
+    RLock lock = getLock(fullKey, lockType);
+
+    boolean acquired = false;
+    try {
+      acquired = lock.tryLock(waitTime.toMillis(), leaseTime.toMillis(), TimeUnit.MILLISECONDS);
+
+      if (!acquired) {
+        LOG.debug("Failed to acquire lock [{}] for callback execution", fullKey);
+        return null;
+      }
+
+      LOG.debug("Lock [{}] acquired for callback execution", fullKey);
+      return callback.execute();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      LOG.warn("Thread interrupted while waiting for lock [{}]", fullKey);
+      return null;
+    } finally {
+      if (acquired) {
+        try {
+          lock.unlock();
+          LOG.debug("Lock [{}] released after callback execution", fullKey);
+        } catch (IllegalMonitorStateException e) {
+          LOG.warn(
+              "Lock [{}] was already released (possibly expired): {}", fullKey, e.getMessage());
+        }
+      }
+    }
+  }
+
+  @NonNull
+  private RLock getLock(@NonNull String fullKey, @NonNull LockType lockType) {
+    return switch (lockType) {
+      case REENTRANT -> redissonClient.getLock(fullKey);
+      case READ -> redissonClient.getReadWriteLock(fullKey).readLock();
+      case WRITE -> redissonClient.getReadWriteLock(fullKey).writeLock();
+    };
+  }
+
+  // ========== Builder Class ==========
+
+  /**
+   * Builder for configuring and executing lock operations.
+   *
+   * <p>This builder provides a fluent API for lock operations with custom configuration. Use {@link
+   * LocksmithLockTemplate#forKey(String)} to create an instance.
+   *
+   * <p>Example usage:
+   *
+   * <pre>{@code
+   * // Acquire with custom timing
+   * boolean acquired = lockTemplate.forKey("my-key")
+   *     .waitTime(Duration.ofSeconds(5))
+   *     .leaseTime(Duration.ofMinutes(2))
+   *     .tryLock();
+   *
+   * // Execute with auto-renew and write lock
+   * String result = lockTemplate.forKey("my-key")
+   *     .lockType(LockType.WRITE)
+   *     .autoRenew()
+   *     .execute(() -> {
+   *         // Long-running operation
+   *         return "done";
+   *     });
+   * }</pre>
+   *
+   * @since 2.1.0
+   */
+  public class LockOperationBuilder {
+
+    private final String key;
+    private Duration waitTime = Duration.ZERO;
+    private Duration leaseTime = lockProperties.leaseTime();
+    private LockType lockType = LockType.REENTRANT;
+
+    private LockOperationBuilder(@NonNull String key) {
+      this.key = key;
+    }
+
+    /**
+     * Sets the maximum time to wait for the lock.
+     *
+     * <p>Default is {@link Duration#ZERO} (no waiting).
+     *
+     * @param waitTime the maximum wait time
+     * @return this builder for chaining
+     */
+    @NonNull
+    public LockOperationBuilder waitTime(@NonNull Duration waitTime) {
+      this.waitTime = waitTime;
+      return this;
+    }
+
+    /**
+     * Sets the lease time after which the lock is automatically released.
+     *
+     * <p>Default is the configured lease time from properties. Use {@link #autoRenew()} instead of
+     * setting a negative value.
+     *
+     * @param leaseTime the lease time
+     * @return this builder for chaining
+     */
+    @NonNull
+    public LockOperationBuilder leaseTime(@NonNull Duration leaseTime) {
+      this.leaseTime = leaseTime;
+      return this;
+    }
+
+    /**
+     * Sets the type of lock to acquire.
+     *
+     * <p>Default is {@link LockType#REENTRANT}.
+     *
+     * @param lockType the lock type (REENTRANT, READ, or WRITE)
+     * @return this builder for chaining
+     */
+    @NonNull
+    public LockOperationBuilder lockType(@NonNull LockType lockType) {
+      this.lockType = lockType;
+      return this;
+    }
+
+    /**
+     * Enables auto-renew mode using Redisson's watchdog.
+     *
+     * <p>When enabled, the lock will be automatically renewed while held, preventing expiration
+     * during long-running operations. This is equivalent to setting lease time to -1ms.
+     *
+     * @return this builder for chaining
+     */
+    @NonNull
+    public LockOperationBuilder autoRenew() {
+      this.leaseTime = Duration.ofMillis(-1);
+      return this;
+    }
+
+    /**
+     * Tries to acquire the lock with the configured settings.
+     *
+     * @return true if the lock was acquired, false otherwise
+     */
+    public boolean tryLock() {
+      return doTryLock(key, waitTime, leaseTime, lockType);
+    }
+
+    /**
+     * Releases the lock with the configured lock type.
+     *
+     * <p>Note: Only the lock type setting affects this operation.
+     */
+    public void unlock() {
+      doUnlock(key, lockType);
+    }
+
+    /**
+     * Checks if the lock is currently held by any thread/instance.
+     *
+     * <p>Note: Only the lock type setting affects this operation.
+     *
+     * @return true if the lock is held by anyone, false otherwise
+     */
+    public boolean isLocked() {
+      return doIsLocked(key, lockType);
+    }
+
+    /**
+     * Executes a callback while holding the lock with the configured settings.
+     *
+     * <p>The lock is automatically released after the callback completes, even if an exception is
+     * thrown.
+     *
+     * @param <T> the type of result returned by the callback
+     * @param callback the callback to execute while holding the lock
+     * @return the result of the callback, or null if the lock could not be acquired
+     * @throws Exception if the callback throws an exception
+     */
+    @Nullable
+    public <T> T execute(@NonNull LockCallback<T> callback) throws Exception {
+      return doExecuteWithLock(key, waitTime, leaseTime, lockType, callback);
+    }
+  }
+}

--- a/src/main/java/in/riido/locksmith/template/LocksmithSemaphoreTemplate.java
+++ b/src/main/java/in/riido/locksmith/template/LocksmithSemaphoreTemplate.java
@@ -1,0 +1,413 @@
+package in.riido.locksmith.template;
+
+import in.riido.locksmith.autoconfigure.LocksmithProperties;
+import in.riido.locksmith.autoconfigure.LocksmithProperties.SemaphoreProperties;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.redisson.api.RBucket;
+import org.redisson.api.RPermitExpirableSemaphore;
+import org.redisson.api.RedissonClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Template class for programmatic distributed semaphore operations.
+ *
+ * <p>This class provides a programmatic API for distributed semaphores, complementing the
+ * annotation-based approach provided by {@link in.riido.locksmith.DistributedSemaphore}. Use this
+ * when you need more control over permit acquisition and release, or when annotations are not
+ * suitable.
+ *
+ * <p>All methods apply the configured key prefix automatically. For example, if the key prefix is
+ * "semaphore:" and you call {@code tryAcquirePermit("my-key", 5)}, the actual Redis key will be
+ * "semaphore:my-key".
+ *
+ * <h2>Simple Usage</h2>
+ *
+ * <pre>{@code
+ * // Acquire and release
+ * String permitId = semaphoreTemplate.tryAcquirePermit("my-key", 5);
+ * if (permitId != null) {
+ *     try {
+ *         // Critical section
+ *     } finally {
+ *         semaphoreTemplate.releasePermit("my-key", permitId);
+ *     }
+ * }
+ *
+ * // Callback-based (recommended)
+ * String result = semaphoreTemplate.executeWithPermit("my-key", 5, () -> {
+ *     return "executed";
+ * });
+ * }</pre>
+ *
+ * <h2>Builder for Complex Cases</h2>
+ *
+ * <pre>{@code
+ * // With custom timing
+ * String permitId = semaphoreTemplate.forKey("my-key", 5)
+ *     .waitTime(Duration.ofSeconds(10))
+ *     .leaseTime(Duration.ofMinutes(2))
+ *     .tryAcquire();
+ *
+ * // Execute with custom timing
+ * String result = semaphoreTemplate.forKey("my-key", 5)
+ *     .waitTime(Duration.ofSeconds(10))
+ *     .execute(() -> {
+ *         return "done";
+ *     });
+ * }</pre>
+ *
+ * @author Garvit Joshi
+ * @since 2.1.0
+ * @see SemaphoreCallback
+ * @see SemaphoreOperationBuilder
+ * @see in.riido.locksmith.DistributedSemaphore
+ */
+public class LocksmithSemaphoreTemplate {
+
+  private static final Logger LOG = LoggerFactory.getLogger(LocksmithSemaphoreTemplate.class);
+  private static final String META_SUFFIX = ":meta";
+
+  private final RedissonClient redissonClient;
+  private final SemaphoreProperties semaphoreProperties;
+
+  /** Cache to track which keys have been initialized in Redis by this JVM. */
+  private final Map<String, Boolean> initializedKeys = new ConcurrentHashMap<>();
+
+  /**
+   * Constructs a new LocksmithSemaphoreTemplate.
+   *
+   * @param redissonClient the Redisson client for Redis operations
+   * @param properties the configuration properties
+   */
+  public LocksmithSemaphoreTemplate(
+      @NonNull RedissonClient redissonClient, @NonNull LocksmithProperties properties) {
+    this.redissonClient = redissonClient;
+    this.semaphoreProperties = properties.semaphore();
+  }
+
+  // ========== Simple Methods ==========
+
+  /**
+   * Tries to acquire a permit immediately without waiting.
+   *
+   * <p>Uses the default lease time from configuration. The semaphore will be initialized with the
+   * specified number of permits if it doesn't exist. For more control, use {@link #forKey(String,
+   * int)}.
+   *
+   * @param key the semaphore key (prefix will be applied automatically)
+   * @param permits the total number of permits for this semaphore
+   * @return the permit ID if acquired, or null if no permit was available
+   */
+  @Nullable
+  public String tryAcquirePermit(@NonNull String key, int permits) {
+    return doTryAcquirePermit(key, permits, Duration.ZERO, semaphoreProperties.leaseTime());
+  }
+
+  /**
+   * Releases a permit back to the semaphore.
+   *
+   * @param key the semaphore key (prefix will be applied automatically)
+   * @param permitId the permit ID returned by tryAcquirePermit
+   */
+  public void releasePermit(@NonNull String key, @NonNull String permitId) {
+    String fullKey = semaphoreProperties.keyPrefix() + key;
+    RPermitExpirableSemaphore semaphore = redissonClient.getPermitExpirableSemaphore(fullKey);
+
+    try {
+      semaphore.release(permitId);
+      LOG.debug("Permit [{}] released from semaphore [{}]", permitId, fullKey);
+    } catch (IllegalArgumentException e) {
+      LOG.warn(
+          "Failed to release permit [{}] from [{}] - permit may have expired: {}",
+          permitId,
+          fullKey,
+          e.getMessage());
+    } catch (Exception e) {
+      LOG.warn("Failed to release permit [{}] from [{}]: {}", permitId, fullKey, e.getMessage());
+    }
+  }
+
+  /**
+   * Executes a callback while holding a semaphore permit.
+   *
+   * <p>Tries to acquire a permit immediately without waiting. Uses the default lease time from
+   * configuration. For more control, use {@link #forKey(String, int)}.
+   *
+   * @param <T> the type of result returned by the callback
+   * @param key the semaphore key (prefix will be applied automatically)
+   * @param permits the total number of permits for this semaphore
+   * @param callback the callback to execute while holding the permit
+   * @return the result of the callback, or null if a permit could not be acquired
+   * @throws Exception if the callback throws an exception
+   */
+  @Nullable
+  public <T> T executeWithPermit(
+      @NonNull String key, int permits, @NonNull SemaphoreCallback<T> callback) throws Exception {
+    return doExecuteWithPermit(
+        key, permits, Duration.ZERO, semaphoreProperties.leaseTime(), callback);
+  }
+
+  // ========== Builder Entry Point ==========
+
+  /**
+   * Creates a builder for semaphore operations on the specified key.
+   *
+   * <p>Use the builder when you need to customize wait time or lease time.
+   *
+   * <pre>{@code
+   * // Custom timing
+   * String permitId = semaphoreTemplate.forKey("my-key", 5)
+   *     .waitTime(Duration.ofSeconds(10))
+   *     .leaseTime(Duration.ofMinutes(2))
+   *     .tryAcquire();
+   *
+   * // Execute with custom wait time
+   * semaphoreTemplate.forKey("my-key", 5)
+   *     .waitTime(Duration.ofSeconds(10))
+   *     .execute(() -> doWork());
+   * }</pre>
+   *
+   * @param key the semaphore key (prefix will be applied automatically)
+   * @param permits the total number of permits for this semaphore
+   * @return a builder for configuring and executing semaphore operations
+   */
+  @NonNull
+  public SemaphoreOperationBuilder forKey(@NonNull String key, int permits) {
+    return new SemaphoreOperationBuilder(key, permits);
+  }
+
+  // ========== Internal Methods ==========
+
+  @Nullable
+  private String doTryAcquirePermit(
+      @NonNull String key, int permits, @NonNull Duration waitTime, @NonNull Duration leaseTime) {
+    if (permits <= 0) {
+      throw new IllegalArgumentException("Permits must be positive, got: " + permits);
+    }
+
+    String fullKey = semaphoreProperties.keyPrefix() + key;
+    ensureSemaphoreInitialized(fullKey, permits);
+
+    RPermitExpirableSemaphore semaphore = redissonClient.getPermitExpirableSemaphore(fullKey);
+
+    try {
+      String permitId =
+          semaphore.tryAcquire(waitTime.toMillis(), leaseTime.toMillis(), TimeUnit.MILLISECONDS);
+      if (permitId != null) {
+        LOG.debug("Permit [{}] acquired from semaphore [{}]", permitId, fullKey);
+      } else {
+        LOG.debug("Failed to acquire permit from semaphore [{}]", fullKey);
+      }
+      return permitId;
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      LOG.warn("Thread interrupted while waiting for permit from [{}]", fullKey);
+      return null;
+    }
+  }
+
+  @Nullable
+  private <T> T doExecuteWithPermit(
+      @NonNull String key,
+      int permits,
+      @NonNull Duration waitTime,
+      @NonNull Duration leaseTime,
+      @NonNull SemaphoreCallback<T> callback)
+      throws Exception {
+    if (permits <= 0) {
+      throw new IllegalArgumentException("Permits must be positive, got: " + permits);
+    }
+
+    String fullKey = semaphoreProperties.keyPrefix() + key;
+    ensureSemaphoreInitialized(fullKey, permits);
+
+    RPermitExpirableSemaphore semaphore = redissonClient.getPermitExpirableSemaphore(fullKey);
+
+    String permitId = null;
+    try {
+      permitId =
+          semaphore.tryAcquire(waitTime.toMillis(), leaseTime.toMillis(), TimeUnit.MILLISECONDS);
+
+      if (permitId == null) {
+        LOG.debug("Failed to acquire permit from [{}] for callback execution", fullKey);
+        return null;
+      }
+
+      LOG.debug("Permit [{}] acquired from [{}] for callback execution", permitId, fullKey);
+      return callback.execute();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      LOG.warn("Thread interrupted while waiting for permit from [{}]", fullKey);
+      return null;
+    } finally {
+      if (permitId != null) {
+        try {
+          semaphore.release(permitId);
+          LOG.debug("Permit [{}] released from [{}] after callback execution", permitId, fullKey);
+        } catch (IllegalArgumentException e) {
+          LOG.warn(
+              "Permit [{}] was already released (possibly expired) from [{}]: {}",
+              permitId,
+              fullKey,
+              e.getMessage());
+        } catch (Exception e) {
+          LOG.warn(
+              "Failed to release permit [{}] from [{}]: {}", permitId, fullKey, e.getMessage());
+        }
+      }
+    }
+  }
+
+  /**
+   * Ensures the semaphore is initialized in Redis with the configured permits.
+   *
+   * <p>Uses metadata storage to detect and warn about permit mismatches across deployments. This
+   * method is thread-safe and will only initialize each semaphore once per JVM.
+   *
+   * @param fullKey the full semaphore key including prefix
+   * @param permits the number of permits to initialize with
+   */
+  private void ensureSemaphoreInitialized(@NonNull String fullKey, int permits) {
+    if (initializedKeys.containsKey(fullKey)) {
+      return;
+    }
+
+    String metaKey = fullKey + META_SUFFIX;
+    RBucket<Integer> metaBucket = redissonClient.getBucket(metaKey);
+    RPermitExpirableSemaphore semaphore = redissonClient.getPermitExpirableSemaphore(fullKey);
+
+    Integer existingPermits = metaBucket.get();
+
+    if (existingPermits == null) {
+      boolean created = semaphore.trySetPermits(permits);
+      if (created) {
+        metaBucket.set(permits);
+        LOG.info("Created semaphore [{}] with {} permits", fullKey, permits);
+      } else {
+        existingPermits = metaBucket.get();
+        if (existingPermits != null && existingPermits != permits) {
+          LOG.warn(
+              "Semaphore [{}] was created by another instance with {} permits, "
+                  + "but this instance configured {} permits. Using existing value. "
+                  + "To change: delete Redis keys '{}' and '{}', then restart.",
+              fullKey,
+              existingPermits,
+              permits,
+              fullKey,
+              metaKey);
+        }
+      }
+    } else if (existingPermits != permits) {
+      LOG.warn(
+          "Semaphore [{}] exists with {} permits, but this instance configured {} permits. "
+              + "Using existing value. To change: delete Redis keys '{}' and '{}', then restart.",
+          fullKey,
+          existingPermits,
+          permits,
+          fullKey,
+          metaKey);
+    }
+
+    initializedKeys.put(fullKey, Boolean.TRUE);
+  }
+
+  // ========== Builder Class ==========
+
+  /**
+   * Builder for configuring and executing semaphore operations.
+   *
+   * <p>This builder provides a fluent API for semaphore operations with custom configuration. Use
+   * {@link LocksmithSemaphoreTemplate#forKey(String, int)} to create an instance.
+   *
+   * <p>Example usage:
+   *
+   * <pre>{@code
+   * // Acquire with custom timing
+   * String permitId = semaphoreTemplate.forKey("my-key", 5)
+   *     .waitTime(Duration.ofSeconds(10))
+   *     .leaseTime(Duration.ofMinutes(2))
+   *     .tryAcquire();
+   *
+   * // Execute with custom wait time
+   * String result = semaphoreTemplate.forKey("my-key", 5)
+   *     .waitTime(Duration.ofSeconds(10))
+   *     .execute(() -> {
+   *         return "done";
+   *     });
+   * }</pre>
+   *
+   * @since 2.1.0
+   */
+  public class SemaphoreOperationBuilder {
+
+    private final String key;
+    private final int permits;
+    private Duration waitTime = Duration.ZERO;
+    private Duration leaseTime = semaphoreProperties.leaseTime();
+
+    private SemaphoreOperationBuilder(@NonNull String key, int permits) {
+      this.key = key;
+      this.permits = permits;
+    }
+
+    /**
+     * Sets the maximum time to wait for a permit.
+     *
+     * <p>Default is {@link Duration#ZERO} (no waiting).
+     *
+     * @param waitTime the maximum wait time
+     * @return this builder for chaining
+     */
+    @NonNull
+    public SemaphoreOperationBuilder waitTime(@NonNull Duration waitTime) {
+      this.waitTime = waitTime;
+      return this;
+    }
+
+    /**
+     * Sets the lease time after which the permit is automatically released.
+     *
+     * <p>Default is the configured lease time from properties.
+     *
+     * @param leaseTime the lease time
+     * @return this builder for chaining
+     */
+    @NonNull
+    public SemaphoreOperationBuilder leaseTime(@NonNull Duration leaseTime) {
+      this.leaseTime = leaseTime;
+      return this;
+    }
+
+    /**
+     * Tries to acquire a permit with the configured settings.
+     *
+     * @return the permit ID if acquired, or null if no permit was available
+     */
+    @Nullable
+    public String tryAcquire() {
+      return doTryAcquirePermit(key, permits, waitTime, leaseTime);
+    }
+
+    /**
+     * Executes a callback while holding a permit with the configured settings.
+     *
+     * <p>The permit is automatically released after the callback completes, even if an exception is
+     * thrown.
+     *
+     * @param <T> the type of result returned by the callback
+     * @param callback the callback to execute while holding the permit
+     * @return the result of the callback, or null if a permit could not be acquired
+     * @throws Exception if the callback throws an exception
+     */
+    @Nullable
+    public <T> T execute(@NonNull SemaphoreCallback<T> callback) throws Exception {
+      return doExecuteWithPermit(key, permits, waitTime, leaseTime, callback);
+    }
+  }
+}

--- a/src/main/java/in/riido/locksmith/template/SemaphoreCallback.java
+++ b/src/main/java/in/riido/locksmith/template/SemaphoreCallback.java
@@ -1,0 +1,36 @@
+package in.riido.locksmith.template;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Functional interface for code to be executed while holding a distributed semaphore permit.
+ *
+ * <p>This callback is used with {@link LocksmithSemaphoreTemplate#executeWithPermit} to execute
+ * code while holding a semaphore permit. The callback may throw any exception, which will be
+ * propagated to the caller after the permit is released.
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * String result = semaphoreTemplate.executeWithPermit("my-key", 5, () -> {
+ *     // Code executed while holding the permit
+ *     return "result";
+ * });
+ * }</pre>
+ *
+ * @param <T> the type of result returned by the callback
+ * @author Garvit Joshi
+ * @since 2.1.0
+ * @see LocksmithSemaphoreTemplate
+ */
+@FunctionalInterface
+public interface SemaphoreCallback<T> {
+
+  /**
+   * Executes the callback logic while holding the semaphore permit.
+   *
+   * @return the result of the execution, may be null
+   * @throws Exception if any error occurs during execution
+   */
+  @Nullable T execute() throws Exception;
+}

--- a/src/main/java/in/riido/locksmith/template/package-info.java
+++ b/src/main/java/in/riido/locksmith/template/package-info.java
@@ -1,0 +1,44 @@
+/**
+ * Programmatic API for distributed locks and semaphores.
+ *
+ * <p>This package provides template classes for programmatic access to distributed locks and
+ * semaphores, complementing the annotation-based approach provided by {@link
+ * in.riido.locksmith.DistributedLock} and {@link in.riido.locksmith.DistributedSemaphore}.
+ *
+ * <p>Key classes:
+ *
+ * <ul>
+ *   <li>{@link in.riido.locksmith.template.LocksmithLockTemplate} - Template for distributed lock
+ *       operations
+ *   <li>{@link in.riido.locksmith.template.LocksmithSemaphoreTemplate} - Template for distributed
+ *       semaphore operations
+ *   <li>{@link in.riido.locksmith.template.LockCallback} - Callback interface for lock execution
+ *   <li>{@link in.riido.locksmith.template.SemaphoreCallback} - Callback interface for semaphore
+ *       execution
+ * </ul>
+ *
+ * <p>Usage example:
+ *
+ * <pre>{@code
+ * @Autowired
+ * private LocksmithLockTemplate lockTemplate;
+ *
+ * // Manual lock management
+ * if (lockTemplate.tryLock("my-key")) {
+ *     try {
+ *         // Critical section
+ *     } finally {
+ *         lockTemplate.unlock("my-key");
+ *     }
+ * }
+ *
+ * // Callback-based execution
+ * String result = lockTemplate.executeWithLock("my-key", () -> {
+ *     return "executed within lock";
+ * });
+ * }</pre>
+ *
+ * @author Garvit Joshi
+ * @since 2.1.0
+ */
+package in.riido.locksmith.template;

--- a/src/test/java/in/riido/locksmith/aspect/DistributedLockAspectTest.java
+++ b/src/test/java/in/riido/locksmith/aspect/DistributedLockAspectTest.java
@@ -60,6 +60,10 @@ class DistributedLockAspectTest {
     when(methodSignature.getName()).thenReturn("testMethod");
     when(joinPoint.getArgs()).thenReturn(new Object[] {});
     when(methodSignature.getReturnType()).thenReturn(void.class);
+    final var keys = redissonClient.getKeys();
+    if (keys != null && keys.count() > 0) {
+      keys.flushall();
+    }
   }
 
   private void setupAnnotation(

--- a/src/test/java/in/riido/locksmith/aspect/DistributedSemaphoreAspectTest.java
+++ b/src/test/java/in/riido/locksmith/aspect/DistributedSemaphoreAspectTest.java
@@ -72,6 +72,10 @@ class DistributedSemaphoreAspectTest {
     doReturn(metaBucket).when(redissonClient).getBucket(anyString());
     when(metaBucket.get()).thenReturn(null);
     when(semaphore.trySetPermits(anyInt())).thenReturn(true);
+    final var keys = redissonClient.getKeys();
+    if (keys != null && keys.count() > 0) {
+      keys.flushall();
+    }
   }
 
   public static class TestService {

--- a/src/test/java/in/riido/locksmith/integration/ConcurrentAccessTest.java
+++ b/src/test/java/in/riido/locksmith/integration/ConcurrentAccessTest.java
@@ -68,6 +68,10 @@ class ConcurrentAccessTest {
     factory.setProxyTargetClass(true);
     factory.addAspect(aspect);
     testService = factory.getProxy();
+    final var keys = redissonClient.getKeys();
+    if (keys != null && keys.count() > 0) {
+      keys.flushall();
+    }
   }
 
   @AfterEach

--- a/src/test/java/in/riido/locksmith/integration/DistributedLockIntegrationTest.java
+++ b/src/test/java/in/riido/locksmith/integration/DistributedLockIntegrationTest.java
@@ -64,6 +64,10 @@ class DistributedLockIntegrationTest {
     factory.setProxyTargetClass(true);
     factory.addAspect(aspect);
     testService = factory.getProxy();
+    final var keys = redissonClient.getKeys();
+    if (keys != null && keys.count() > 0) {
+      keys.flushall();
+    }
   }
 
   @AfterEach

--- a/src/test/java/in/riido/locksmith/integration/DistributedSemaphoreIntegrationTest.java
+++ b/src/test/java/in/riido/locksmith/integration/DistributedSemaphoreIntegrationTest.java
@@ -79,6 +79,10 @@ class DistributedSemaphoreIntegrationTest {
     factory.setProxyTargetClass(true);
     factory.addAspect(aspect);
     testService = factory.getProxy();
+    final var keys = redissonClient.getKeys();
+    if (keys != null && keys.count() > 0) {
+      keys.flushall();
+    }
   }
 
   @AfterEach

--- a/src/test/java/in/riido/locksmith/integration/LocksmithLockTemplateIntegrationTest.java
+++ b/src/test/java/in/riido/locksmith/integration/LocksmithLockTemplateIntegrationTest.java
@@ -1,0 +1,387 @@
+package in.riido.locksmith.integration;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import in.riido.locksmith.LockType;
+import in.riido.locksmith.autoconfigure.LocksmithProperties;
+import in.riido.locksmith.template.LocksmithLockTemplate;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+@ExtendWith(DockerAvailableCondition.class)
+@DisplayName("LocksmithLockTemplate Integration Tests")
+class LocksmithLockTemplateIntegrationTest {
+
+  private static final int REDIS_PORT = 6379;
+
+  @Container
+  static GenericContainer<?> redis =
+      new GenericContainer<>(DockerImageName.parse("redis:latest")).withExposedPorts(REDIS_PORT);
+
+  private RedissonClient redissonClient;
+  private LocksmithLockTemplate template;
+
+  @BeforeEach
+  void setUp() {
+    Config config = new Config();
+    config
+        .useSingleServer()
+        .setAddress("redis://" + redis.getHost() + ":" + redis.getMappedPort(REDIS_PORT));
+    redissonClient = Redisson.create(config);
+
+    LocksmithProperties properties =
+        new LocksmithProperties(
+            new LocksmithProperties.LockProperties(
+                Duration.ofMinutes(1), Duration.ofSeconds(10), "test:", false),
+            null);
+    template = new LocksmithLockTemplate(redissonClient, properties);
+    final var keys = redissonClient.getKeys();
+    if (keys != null && keys.count() > 0) {
+      keys.flushall();
+    }
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (redissonClient != null && !redissonClient.isShutdown()) {
+      redissonClient.shutdown();
+    }
+  }
+
+  @Nested
+  @DisplayName("Basic Lock Operations")
+  class BasicLockOperations {
+
+    @Test
+    @DisplayName("Should acquire and release lock")
+    void shouldAcquireAndReleaseLock() {
+      assertTrue(template.tryLock("basic-test"));
+      assertTrue(template.isLocked("basic-test"));
+      template.unlock("basic-test");
+      assertFalse(template.isLocked("basic-test"));
+    }
+
+    @Test
+    @DisplayName("Should execute callback within lock")
+    void shouldExecuteCallbackWithinLock() throws Exception {
+      String result =
+          template.executeWithLock(
+              "callback-test",
+              () -> {
+                assertTrue(template.isLocked("callback-test"));
+                return "success";
+              });
+
+      assertEquals("success", result);
+      assertFalse(template.isLocked("callback-test"));
+    }
+
+    @Test
+    @DisplayName("Should release lock after callback exception")
+    void shouldReleaseLockAfterCallbackException() {
+      assertThrows(
+          RuntimeException.class,
+          () ->
+              template.executeWithLock(
+                  "exception-test",
+                  () -> {
+                    throw new RuntimeException("Test error");
+                  }));
+
+      assertFalse(template.isLocked("exception-test"));
+    }
+  }
+
+  @Nested
+  @DisplayName("Lock Contention")
+  class LockContention {
+
+    @Test
+    @DisplayName("Should prevent concurrent access to same lock")
+    void shouldPreventConcurrentAccess() throws InterruptedException {
+      AtomicInteger concurrentExecutions = new AtomicInteger(0);
+      AtomicInteger maxConcurrent = new AtomicInteger(0);
+      CountDownLatch latch = new CountDownLatch(5);
+      ExecutorService executor = Executors.newFixedThreadPool(5);
+
+      for (int i = 0; i < 5; i++) {
+        executor.submit(
+            () -> {
+              try {
+                template
+                    .forKey("contention-test")
+                    .waitTime(Duration.ofSeconds(10))
+                    .execute(
+                        () -> {
+                          int current = concurrentExecutions.incrementAndGet();
+                          maxConcurrent.updateAndGet(max -> Math.max(max, current));
+                          Thread.sleep(50);
+                          concurrentExecutions.decrementAndGet();
+                          return null;
+                        });
+              } catch (Exception e) {
+                // Ignore
+              } finally {
+                latch.countDown();
+              }
+            });
+      }
+
+      assertTrue(latch.await(30, TimeUnit.SECONDS));
+      assertEquals(1, maxConcurrent.get(), "Only one thread should execute at a time");
+      executor.shutdown();
+    }
+
+    @Test
+    @DisplayName("Should return false immediately when lock held by another")
+    void shouldReturnFalseWhenLockHeld() throws Exception {
+      // Acquire lock in current thread
+      assertTrue(template.tryLock("held-lock"));
+
+      // Try to acquire from another thread
+      ExecutorService executor = Executors.newSingleThreadExecutor();
+      Boolean otherThreadResult =
+          executor
+              .submit(
+                  () -> {
+                    return template.tryLock("held-lock");
+                  })
+              .get(5, TimeUnit.SECONDS);
+
+      assertFalse(otherThreadResult);
+      template.unlock("held-lock");
+      executor.shutdown();
+    }
+
+    @Test
+    @DisplayName("Should acquire lock after release by another thread")
+    void shouldAcquireLockAfterRelease() throws Exception {
+      CountDownLatch lockAcquired = new CountDownLatch(1);
+      CountDownLatch lockReleased = new CountDownLatch(1);
+      AtomicInteger secondThreadAcquired = new AtomicInteger(0);
+
+      Thread firstThread =
+          new Thread(
+              () -> {
+                template.tryLock("release-test");
+                lockAcquired.countDown();
+                try {
+                  Thread.sleep(100);
+                } catch (InterruptedException e) {
+                  Thread.currentThread().interrupt();
+                }
+                template.unlock("release-test");
+                lockReleased.countDown();
+              });
+
+      Thread secondThread =
+          new Thread(
+              () -> {
+                try {
+                  lockAcquired.await();
+                  if (template.forKey("release-test").waitTime(Duration.ofSeconds(5)).tryLock()) {
+                    secondThreadAcquired.set(1);
+                    template.unlock("release-test");
+                  }
+                } catch (InterruptedException e) {
+                  Thread.currentThread().interrupt();
+                }
+              });
+
+      firstThread.start();
+      secondThread.start();
+      firstThread.join(10000);
+      secondThread.join(10000);
+
+      assertEquals(1, secondThreadAcquired.get());
+    }
+  }
+
+  @Nested
+  @DisplayName("Read-Write Locks via Builder")
+  class ReadWriteLocks {
+
+    @Test
+    @DisplayName("Should allow multiple concurrent read locks")
+    void shouldAllowConcurrentReadLocks() throws InterruptedException {
+      AtomicInteger concurrentReaders = new AtomicInteger(0);
+      AtomicInteger maxConcurrent = new AtomicInteger(0);
+      CountDownLatch allStarted = new CountDownLatch(3);
+      CountDownLatch allComplete = new CountDownLatch(3);
+
+      ExecutorService executor = Executors.newFixedThreadPool(3);
+
+      for (int i = 0; i < 3; i++) {
+        executor.submit(
+            () -> {
+              try {
+                if (template
+                    .forKey("rw-read-test")
+                    .waitTime(Duration.ofSeconds(5))
+                    .leaseTime(Duration.ofMinutes(1))
+                    .lockType(LockType.READ)
+                    .tryLock()) {
+                  try {
+                    int current = concurrentReaders.incrementAndGet();
+                    maxConcurrent.updateAndGet(max -> Math.max(max, current));
+                    allStarted.countDown();
+                    Thread.sleep(200);
+                    concurrentReaders.decrementAndGet();
+                  } finally {
+                    template.forKey("rw-read-test").lockType(LockType.READ).unlock();
+                  }
+                }
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+              } finally {
+                allComplete.countDown();
+              }
+            });
+      }
+
+      assertTrue(allComplete.await(15, TimeUnit.SECONDS));
+      assertTrue(maxConcurrent.get() > 1, "Multiple readers should run concurrently");
+      executor.shutdown();
+    }
+
+    @Test
+    @DisplayName("Should block write lock when read lock held")
+    void shouldBlockWriteWhenReadHeld() throws Exception {
+      // Acquire read lock via builder
+      assertTrue(
+          template
+              .forKey("rw-block-test")
+              .leaseTime(Duration.ofMinutes(1))
+              .lockType(LockType.READ)
+              .tryLock());
+
+      // Try write lock from another thread
+      ExecutorService executor = Executors.newSingleThreadExecutor();
+      Boolean writeResult =
+          executor
+              .submit(
+                  () -> {
+                    return template
+                        .forKey("rw-block-test")
+                        .leaseTime(Duration.ofMinutes(1))
+                        .lockType(LockType.WRITE)
+                        .tryLock();
+                  })
+              .get(5, TimeUnit.SECONDS);
+
+      assertFalse(writeResult);
+      template.forKey("rw-block-test").lockType(LockType.READ).unlock();
+      executor.shutdown();
+    }
+
+    @Test
+    @DisplayName("Should block read lock when write lock held")
+    void shouldBlockReadWhenWriteHeld() throws Exception {
+      // Acquire write lock via builder
+      assertTrue(
+          template
+              .forKey("rw-block-test2")
+              .leaseTime(Duration.ofMinutes(1))
+              .lockType(LockType.WRITE)
+              .tryLock());
+
+      // Try read lock from another thread
+      ExecutorService executor = Executors.newSingleThreadExecutor();
+      Boolean readResult =
+          executor
+              .submit(
+                  () -> {
+                    return template
+                        .forKey("rw-block-test2")
+                        .leaseTime(Duration.ofMinutes(1))
+                        .lockType(LockType.READ)
+                        .tryLock();
+                  })
+              .get(5, TimeUnit.SECONDS);
+
+      assertFalse(readResult);
+      template.forKey("rw-block-test2").lockType(LockType.WRITE).unlock();
+      executor.shutdown();
+    }
+  }
+
+  @Nested
+  @DisplayName("Auto-Renew via Builder")
+  class AutoRenew {
+
+    @Test
+    @DisplayName("Should auto-renew lock beyond original lease time")
+    void shouldAutoRenewLock() throws Exception {
+      // Use autoRenew() via builder
+      String result =
+          template
+              .forKey("auto-renew-test")
+              .autoRenew()
+              .execute(
+                  () -> {
+                    // Sleep longer than would be allowed without auto-renew
+                    Thread.sleep(2000);
+                    return "completed";
+                  });
+
+      assertEquals("completed", result);
+      assertFalse(template.isLocked("auto-renew-test"));
+    }
+  }
+
+  @Nested
+  @DisplayName("Different Keys")
+  class DifferentKeys {
+
+    @Test
+    @DisplayName("Should allow concurrent locks on different keys")
+    void shouldAllowConcurrentLocksOnDifferentKeys() throws InterruptedException {
+      AtomicInteger completedCount = new AtomicInteger(0);
+      CountDownLatch latch = new CountDownLatch(3);
+
+      ExecutorService executor = Executors.newFixedThreadPool(3);
+
+      for (int i = 0; i < 3; i++) {
+        final String key = "key-" + i;
+        executor.submit(
+            () -> {
+              try {
+                template.executeWithLock(
+                    key,
+                    () -> {
+                      Thread.sleep(100);
+                      completedCount.incrementAndGet();
+                      return null;
+                    });
+              } catch (Exception e) {
+                // Ignore
+              } finally {
+                latch.countDown();
+              }
+            });
+      }
+
+      assertTrue(latch.await(10, TimeUnit.SECONDS));
+      assertEquals(3, completedCount.get());
+      executor.shutdown();
+    }
+  }
+}

--- a/src/test/java/in/riido/locksmith/integration/LocksmithSemaphoreTemplateIntegrationTest.java
+++ b/src/test/java/in/riido/locksmith/integration/LocksmithSemaphoreTemplateIntegrationTest.java
@@ -1,0 +1,366 @@
+package in.riido.locksmith.integration;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import in.riido.locksmith.autoconfigure.LocksmithProperties;
+import in.riido.locksmith.template.LocksmithSemaphoreTemplate;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+@ExtendWith(DockerAvailableCondition.class)
+@DisplayName("LocksmithSemaphoreTemplate Integration Tests")
+class LocksmithSemaphoreTemplateIntegrationTest {
+
+  private static final int REDIS_PORT = 6379;
+
+  @Container
+  static GenericContainer<?> redis =
+      new GenericContainer<>(DockerImageName.parse("redis:latest")).withExposedPorts(REDIS_PORT);
+
+  private RedissonClient redissonClient;
+  private LocksmithSemaphoreTemplate template;
+
+  @BeforeEach
+  void setUp() {
+    Config config = new Config();
+    config
+        .useSingleServer()
+        .setAddress("redis://" + redis.getHost() + ":" + redis.getMappedPort(REDIS_PORT));
+    redissonClient = Redisson.create(config);
+
+    LocksmithProperties properties =
+        new LocksmithProperties(
+            null,
+            new LocksmithProperties.SemaphoreProperties(
+                Duration.ofMinutes(1), Duration.ofSeconds(10), "test:", false));
+    template = new LocksmithSemaphoreTemplate(redissonClient, properties);
+    final var keys = redissonClient.getKeys();
+    if (keys != null && keys.count() > 0) {
+      keys.flushall();
+    }
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (redissonClient != null && !redissonClient.isShutdown()) {
+      redissonClient.shutdown();
+    }
+  }
+
+  @Nested
+  @DisplayName("Basic Permit Operations")
+  class BasicPermitOperations {
+
+    @Test
+    @DisplayName("Should acquire and release permit")
+    void shouldAcquireAndReleasePermit() {
+      String permitId = template.tryAcquirePermit("basic-test", 5);
+      assertNotNull(permitId);
+      template.releasePermit("basic-test", permitId);
+    }
+
+    @Test
+    @DisplayName("Should execute callback while holding permit")
+    void shouldExecuteCallbackWithPermit() throws Exception {
+      AtomicInteger executed = new AtomicInteger(0);
+
+      String result =
+          template.executeWithPermit(
+              "callback-test",
+              5,
+              () -> {
+                executed.set(1);
+                return "success";
+              });
+
+      assertEquals("success", result);
+      assertEquals(1, executed.get());
+    }
+
+    @Test
+    @DisplayName("Should release permit after callback exception")
+    void shouldReleasePermitAfterCallbackException() {
+      assertThrows(
+          RuntimeException.class,
+          () ->
+              template.executeWithPermit(
+                  "exception-test",
+                  5,
+                  () -> {
+                    throw new RuntimeException("Test error");
+                  }));
+
+      // Should be able to acquire permit again
+      String permitId = template.tryAcquirePermit("exception-test", 5);
+      assertNotNull(permitId);
+      template.releasePermit("exception-test", permitId);
+    }
+  }
+
+  @Nested
+  @DisplayName("Permit Limiting")
+  class PermitLimiting {
+
+    @Test
+    @DisplayName("Should limit concurrent access to number of permits")
+    void shouldLimitConcurrentAccess() throws InterruptedException {
+      int maxPermits = 3;
+      AtomicInteger concurrentExecutions = new AtomicInteger(0);
+      AtomicInteger maxConcurrent = new AtomicInteger(0);
+      CountDownLatch latch = new CountDownLatch(10);
+      ExecutorService executor = Executors.newFixedThreadPool(10);
+
+      for (int i = 0; i < 10; i++) {
+        executor.submit(
+            () -> {
+              try {
+                template
+                    .forKey("limit-test", maxPermits)
+                    .waitTime(Duration.ofSeconds(10))
+                    .execute(
+                        () -> {
+                          int current = concurrentExecutions.incrementAndGet();
+                          maxConcurrent.updateAndGet(max -> Math.max(max, current));
+                          Thread.sleep(100);
+                          concurrentExecutions.decrementAndGet();
+                          return null;
+                        });
+              } catch (Exception e) {
+                // Ignore
+              } finally {
+                latch.countDown();
+              }
+            });
+      }
+
+      assertTrue(latch.await(30, TimeUnit.SECONDS));
+      assertTrue(
+          maxConcurrent.get() <= maxPermits,
+          "Max concurrent should not exceed " + maxPermits + ", was: " + maxConcurrent.get());
+      assertTrue(maxConcurrent.get() >= 1, "At least one execution should have occurred");
+      executor.shutdown();
+    }
+
+    @Test
+    @DisplayName("Should return null when all permits are held")
+    void shouldReturnNullWhenAllPermitsHeld() throws Exception {
+      int maxPermits = 2;
+      CountDownLatch permitsAcquired = new CountDownLatch(maxPermits);
+      CountDownLatch testComplete = new CountDownLatch(1);
+
+      ExecutorService executor = Executors.newFixedThreadPool(maxPermits);
+
+      // Acquire all permits
+      for (int i = 0; i < maxPermits; i++) {
+        executor.submit(
+            () -> {
+              try {
+                String permitId = template.tryAcquirePermit("full-test", maxPermits);
+                if (permitId != null) {
+                  permitsAcquired.countDown();
+                  testComplete.await(10, TimeUnit.SECONDS);
+                  template.releasePermit("full-test", permitId);
+                }
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+              }
+            });
+      }
+
+      assertTrue(permitsAcquired.await(5, TimeUnit.SECONDS));
+
+      // Try to acquire when all permits are held
+      String permitId = template.tryAcquirePermit("full-test", maxPermits);
+      assertNull(permitId);
+
+      testComplete.countDown();
+      executor.shutdown();
+      executor.awaitTermination(5, TimeUnit.SECONDS);
+    }
+  }
+
+  @Nested
+  @DisplayName("Wait Time via Builder")
+  class WaitTime {
+
+    @Test
+    @DisplayName("Should wait and acquire permit when one becomes available")
+    void shouldWaitAndAcquirePermit() throws InterruptedException {
+      int maxPermits = 1;
+      CountDownLatch firstPermitAcquired = new CountDownLatch(1);
+      CountDownLatch secondPermitAcquired = new CountDownLatch(1);
+
+      Thread firstThread =
+          new Thread(
+              () -> {
+                String permitId = template.tryAcquirePermit("wait-test", maxPermits);
+                if (permitId != null) {
+                  firstPermitAcquired.countDown();
+                  try {
+                    Thread.sleep(200);
+                  } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                  }
+                  template.releasePermit("wait-test", permitId);
+                }
+              });
+
+      Thread secondThread =
+          new Thread(
+              () -> {
+                try {
+                  firstPermitAcquired.await();
+                  String permitId =
+                      template
+                          .forKey("wait-test", maxPermits)
+                          .waitTime(Duration.ofSeconds(5))
+                          .tryAcquire();
+                  if (permitId != null) {
+                    secondPermitAcquired.countDown();
+                    template.releasePermit("wait-test", permitId);
+                  }
+                } catch (InterruptedException e) {
+                  Thread.currentThread().interrupt();
+                }
+              });
+
+      firstThread.start();
+      secondThread.start();
+
+      assertTrue(secondPermitAcquired.await(10, TimeUnit.SECONDS));
+
+      firstThread.join(5000);
+      secondThread.join(5000);
+    }
+  }
+
+  @Nested
+  @DisplayName("Different Keys")
+  class DifferentKeys {
+
+    @Test
+    @DisplayName("Should allow permits on different keys independently")
+    void shouldAllowPermitsOnDifferentKeys() throws InterruptedException {
+      AtomicInteger completedCount = new AtomicInteger(0);
+      CountDownLatch latch = new CountDownLatch(5);
+
+      ExecutorService executor = Executors.newFixedThreadPool(5);
+
+      for (int i = 0; i < 5; i++) {
+        final String key = "key-" + i;
+        executor.submit(
+            () -> {
+              try {
+                template.executeWithPermit(
+                    key,
+                    1, // Only 1 permit each, but different keys
+                    () -> {
+                      Thread.sleep(50);
+                      completedCount.incrementAndGet();
+                      return null;
+                    });
+              } catch (Exception e) {
+                // Ignore
+              } finally {
+                latch.countDown();
+              }
+            });
+      }
+
+      assertTrue(latch.await(10, TimeUnit.SECONDS));
+      assertEquals(5, completedCount.get());
+      executor.shutdown();
+    }
+  }
+
+  @Nested
+  @DisplayName("Permit Validation")
+  class PermitValidation {
+
+    @Test
+    @DisplayName("Should throw exception for non-positive permits")
+    void shouldThrowExceptionForNonPositivePermits() {
+      assertThrows(
+          IllegalArgumentException.class, () -> template.tryAcquirePermit("invalid-test", 0));
+
+      assertThrows(
+          IllegalArgumentException.class, () -> template.tryAcquirePermit("invalid-test", -1));
+    }
+
+    @Test
+    @DisplayName("Should throw exception for non-positive permits in executeWithPermit")
+    void shouldThrowExceptionForNonPositivePermitsInExecute() {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> template.executeWithPermit("invalid-test", 0, () -> "result"));
+
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> template.executeWithPermit("invalid-test", -1, () -> "result"));
+    }
+  }
+
+  @Nested
+  @DisplayName("Semaphore Initialization")
+  class SemaphoreInitialization {
+
+    @Test
+    @DisplayName("Should initialize semaphore with correct permit count")
+    void shouldInitializeSemaphoreWithCorrectPermitCount() throws InterruptedException {
+      int maxPermits = 3;
+      AtomicInteger concurrentAcquisitions = new AtomicInteger(0);
+      AtomicInteger maxConcurrent = new AtomicInteger(0);
+      CountDownLatch allAcquired = new CountDownLatch(maxPermits);
+      CountDownLatch testComplete = new CountDownLatch(1);
+
+      ExecutorService executor = Executors.newFixedThreadPool(maxPermits + 1);
+
+      // Try to acquire one more than max permits
+      for (int i = 0; i < maxPermits + 1; i++) {
+        executor.submit(
+            () -> {
+              try {
+                String permitId = template.tryAcquirePermit("init-test", maxPermits);
+                if (permitId != null) {
+                  int current = concurrentAcquisitions.incrementAndGet();
+                  maxConcurrent.updateAndGet(max -> Math.max(max, current));
+                  allAcquired.countDown();
+                  testComplete.await(10, TimeUnit.SECONDS);
+                  concurrentAcquisitions.decrementAndGet();
+                  template.releasePermit("init-test", permitId);
+                }
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+              }
+            });
+      }
+
+      // Wait for permits to be acquired
+      Thread.sleep(500);
+      testComplete.countDown();
+      executor.shutdown();
+      executor.awaitTermination(10, TimeUnit.SECONDS);
+
+      assertEquals(
+          maxPermits, maxConcurrent.get(), "Should acquire exactly " + maxPermits + " permits");
+    }
+  }
+}

--- a/src/test/java/in/riido/locksmith/integration/SemaphoreConcurrentAccessTest.java
+++ b/src/test/java/in/riido/locksmith/integration/SemaphoreConcurrentAccessTest.java
@@ -77,6 +77,10 @@ class SemaphoreConcurrentAccessTest {
     factory.setProxyTargetClass(true);
     factory.addAspect(aspect);
     testService = factory.getProxy();
+    final var keys = redissonClient.getKeys();
+    if (keys != null && keys.count() > 0) {
+      keys.flushall();
+    }
   }
 
   @AfterEach

--- a/src/test/java/in/riido/locksmith/integration/StressPerformanceTest.java
+++ b/src/test/java/in/riido/locksmith/integration/StressPerformanceTest.java
@@ -71,6 +71,10 @@ class StressPerformanceTest {
     factory.setProxyTargetClass(true);
     factory.addAspect(aspect);
     testService = factory.getProxy();
+    final var keys = redissonClient.getKeys();
+    if (keys != null && keys.count() > 0) {
+      keys.flushall();
+    }
   }
 
   @AfterEach

--- a/src/test/java/in/riido/locksmith/template/LocksmithLockTemplateTest.java
+++ b/src/test/java/in/riido/locksmith/template/LocksmithLockTemplateTest.java
@@ -1,0 +1,435 @@
+package in.riido.locksmith.template;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import in.riido.locksmith.LockType;
+import in.riido.locksmith.autoconfigure.LocksmithProperties;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.redisson.api.RLock;
+import org.redisson.api.RReadWriteLock;
+import org.redisson.api.RedissonClient;
+
+@DisplayName("LocksmithLockTemplate Tests")
+class LocksmithLockTemplateTest {
+
+  private RedissonClient redissonClient;
+  private LocksmithLockTemplate template;
+  private RLock lock;
+
+  @BeforeEach
+  void setUp() {
+    redissonClient = mock(RedissonClient.class);
+    LocksmithProperties properties =
+        new LocksmithProperties(
+            new LocksmithProperties.LockProperties(
+                Duration.ofMinutes(10), Duration.ofSeconds(60), "lock:", false),
+            null);
+    template = new LocksmithLockTemplate(redissonClient, properties);
+    lock = mock(RLock.class);
+    final var keys = redissonClient.getKeys();
+    if (keys != null && keys.count() > 0) {
+      keys.flushall();
+    }
+  }
+
+  @Nested
+  @DisplayName("Simple tryLock Tests")
+  class SimpleTryLockTests {
+
+    @Test
+    @DisplayName("Should acquire lock immediately with default parameters")
+    void shouldAcquireLockImmediately() throws InterruptedException {
+      when(redissonClient.getLock("lock:my-key")).thenReturn(lock);
+      when(lock.tryLock(0, 600000, TimeUnit.MILLISECONDS)).thenReturn(true);
+
+      boolean result = template.tryLock("my-key");
+
+      assertTrue(result);
+      verify(redissonClient).getLock("lock:my-key");
+      verify(lock).tryLock(0, 600000, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    @DisplayName("Should return false when lock not acquired")
+    void shouldReturnFalseWhenLockNotAcquired() throws InterruptedException {
+      when(redissonClient.getLock("lock:my-key")).thenReturn(lock);
+      when(lock.tryLock(0, 600000, TimeUnit.MILLISECONDS)).thenReturn(false);
+
+      boolean result = template.tryLock("my-key");
+
+      assertFalse(result);
+    }
+
+    @Test
+    @DisplayName("Should return false when interrupted")
+    void shouldReturnFalseWhenInterrupted() throws InterruptedException {
+      when(redissonClient.getLock("lock:my-key")).thenReturn(lock);
+      when(lock.tryLock(anyLong(), anyLong(), eq(TimeUnit.MILLISECONDS)))
+          .thenThrow(new InterruptedException());
+
+      boolean result = template.tryLock("my-key");
+
+      assertFalse(result);
+      assertTrue(Thread.currentThread().isInterrupted());
+      Thread.interrupted(); // Clear interrupt status
+    }
+  }
+
+  @Nested
+  @DisplayName("Builder tryLock Tests")
+  class BuilderTryLockTests {
+
+    @Test
+    @DisplayName("Should use custom wait time via builder")
+    void shouldUseCustomWaitTime() throws InterruptedException {
+      when(redissonClient.getLock("lock:my-key")).thenReturn(lock);
+      when(lock.tryLock(5000, 600000, TimeUnit.MILLISECONDS)).thenReturn(true);
+
+      boolean result = template.forKey("my-key").waitTime(Duration.ofSeconds(5)).tryLock();
+
+      assertTrue(result);
+      verify(lock).tryLock(5000, 600000, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    @DisplayName("Should use custom lease time via builder")
+    void shouldUseCustomLeaseTime() throws InterruptedException {
+      when(redissonClient.getLock("lock:my-key")).thenReturn(lock);
+      when(lock.tryLock(5000, 30000, TimeUnit.MILLISECONDS)).thenReturn(true);
+
+      boolean result =
+          template
+              .forKey("my-key")
+              .waitTime(Duration.ofSeconds(5))
+              .leaseTime(Duration.ofSeconds(30))
+              .tryLock();
+
+      assertTrue(result);
+      verify(lock).tryLock(5000, 30000, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    @DisplayName("Should use autoRenew via builder")
+    void shouldUseAutoRenew() throws InterruptedException {
+      when(redissonClient.getLock("lock:my-key")).thenReturn(lock);
+      when(lock.tryLock(0, -1, TimeUnit.MILLISECONDS)).thenReturn(true);
+
+      boolean result = template.forKey("my-key").autoRenew().tryLock();
+
+      assertTrue(result);
+      verify(lock).tryLock(0, -1, TimeUnit.MILLISECONDS);
+    }
+  }
+
+  @Nested
+  @DisplayName("Lock Type Tests via Builder")
+  class LockTypeTests {
+
+    private RReadWriteLock readWriteLock;
+    private RLock readLock;
+    private RLock writeLock;
+
+    @BeforeEach
+    void setUpReadWriteLock() {
+      readWriteLock = mock(RReadWriteLock.class);
+      readLock = mock(RLock.class);
+      writeLock = mock(RLock.class);
+      when(redissonClient.getReadWriteLock("lock:my-key")).thenReturn(readWriteLock);
+      when(readWriteLock.readLock()).thenReturn(readLock);
+      when(readWriteLock.writeLock()).thenReturn(writeLock);
+    }
+
+    @Test
+    @DisplayName("Should use read lock for READ type via builder")
+    void shouldUseReadLockForReadType() throws InterruptedException {
+      when(readLock.tryLock(0, 600000, TimeUnit.MILLISECONDS)).thenReturn(true);
+
+      boolean result = template.forKey("my-key").lockType(LockType.READ).tryLock();
+
+      assertTrue(result);
+      verify(readWriteLock).readLock();
+      verify(readWriteLock, never()).writeLock();
+    }
+
+    @Test
+    @DisplayName("Should use write lock for WRITE type via builder")
+    void shouldUseWriteLockForWriteType() throws InterruptedException {
+      when(writeLock.tryLock(0, 600000, TimeUnit.MILLISECONDS)).thenReturn(true);
+
+      boolean result = template.forKey("my-key").lockType(LockType.WRITE).tryLock();
+
+      assertTrue(result);
+      verify(readWriteLock).writeLock();
+      verify(readWriteLock, never()).readLock();
+    }
+
+    @Test
+    @DisplayName("Should use reentrant lock for REENTRANT type via builder")
+    void shouldUseReentrantLockForReentrantType() throws InterruptedException {
+      when(redissonClient.getLock("lock:my-key")).thenReturn(lock);
+      when(lock.tryLock(0, 600000, TimeUnit.MILLISECONDS)).thenReturn(true);
+
+      boolean result = template.forKey("my-key").lockType(LockType.REENTRANT).tryLock();
+
+      assertTrue(result);
+      verify(redissonClient).getLock("lock:my-key");
+      verify(redissonClient, never()).getReadWriteLock(anyString());
+    }
+  }
+
+  @Nested
+  @DisplayName("unlock Tests")
+  class UnlockTests {
+
+    @Test
+    @DisplayName("Should unlock reentrant lock via simple method")
+    void shouldUnlockReentrantLock() {
+      when(redissonClient.getLock("lock:my-key")).thenReturn(lock);
+
+      template.unlock("my-key");
+
+      verify(lock).unlock();
+    }
+
+    @Test
+    @DisplayName("Should unlock read lock via builder")
+    void shouldUnlockReadLock() {
+      RReadWriteLock readWriteLock = mock(RReadWriteLock.class);
+      RLock readLock = mock(RLock.class);
+      when(redissonClient.getReadWriteLock("lock:my-key")).thenReturn(readWriteLock);
+      when(readWriteLock.readLock()).thenReturn(readLock);
+
+      template.forKey("my-key").lockType(LockType.READ).unlock();
+
+      verify(readLock).unlock();
+    }
+
+    @Test
+    @DisplayName("Should unlock write lock via builder")
+    void shouldUnlockWriteLock() {
+      RReadWriteLock readWriteLock = mock(RReadWriteLock.class);
+      RLock writeLock = mock(RLock.class);
+      when(redissonClient.getReadWriteLock("lock:my-key")).thenReturn(readWriteLock);
+      when(readWriteLock.writeLock()).thenReturn(writeLock);
+
+      template.forKey("my-key").lockType(LockType.WRITE).unlock();
+
+      verify(writeLock).unlock();
+    }
+
+    @Test
+    @DisplayName("Should handle IllegalMonitorStateException gracefully")
+    void shouldHandleIllegalMonitorStateException() {
+      when(redissonClient.getLock("lock:my-key")).thenReturn(lock);
+      doThrow(new IllegalMonitorStateException("Not held")).when(lock).unlock();
+
+      assertDoesNotThrow(() -> template.unlock("my-key"));
+    }
+  }
+
+  @Nested
+  @DisplayName("isLocked Tests")
+  class IsLockedTests {
+
+    @Test
+    @DisplayName("Should return true when lock is held")
+    void shouldReturnTrueWhenLockIsHeld() {
+      when(redissonClient.getLock("lock:my-key")).thenReturn(lock);
+      when(lock.isLocked()).thenReturn(true);
+
+      assertTrue(template.isLocked("my-key"));
+    }
+
+    @Test
+    @DisplayName("Should return false when lock is not held")
+    void shouldReturnFalseWhenLockIsNotHeld() {
+      when(redissonClient.getLock("lock:my-key")).thenReturn(lock);
+      when(lock.isLocked()).thenReturn(false);
+
+      assertFalse(template.isLocked("my-key"));
+    }
+
+    @Test
+    @DisplayName("Should check correct lock type via builder")
+    void shouldCheckCorrectLockType() {
+      RReadWriteLock readWriteLock = mock(RReadWriteLock.class);
+      RLock writeLock = mock(RLock.class);
+      when(redissonClient.getReadWriteLock("lock:my-key")).thenReturn(readWriteLock);
+      when(readWriteLock.writeLock()).thenReturn(writeLock);
+      when(writeLock.isLocked()).thenReturn(true);
+
+      assertTrue(template.forKey("my-key").lockType(LockType.WRITE).isLocked());
+      verify(readWriteLock).writeLock();
+    }
+  }
+
+  @Nested
+  @DisplayName("Simple executeWithLock Tests")
+  class SimpleExecuteWithLockTests {
+
+    @Test
+    @DisplayName("Should execute callback when lock acquired")
+    void shouldExecuteCallbackWhenLockAcquired() throws Exception {
+      when(redissonClient.getLock("lock:my-key")).thenReturn(lock);
+      when(lock.tryLock(0, 600000, TimeUnit.MILLISECONDS)).thenReturn(true);
+
+      String result = template.executeWithLock("my-key", () -> "result");
+
+      assertEquals("result", result);
+      verify(lock).unlock();
+    }
+
+    @Test
+    @DisplayName("Should return null when lock not acquired")
+    void shouldReturnNullWhenLockNotAcquired() throws Exception {
+      when(redissonClient.getLock("lock:my-key")).thenReturn(lock);
+      when(lock.tryLock(0, 600000, TimeUnit.MILLISECONDS)).thenReturn(false);
+
+      String result = template.executeWithLock("my-key", () -> "result");
+
+      assertNull(result);
+      verify(lock, never()).unlock();
+    }
+
+    @Test
+    @DisplayName("Should release lock even when callback throws exception")
+    void shouldReleaseLockWhenCallbackThrows() throws InterruptedException {
+      when(redissonClient.getLock("lock:my-key")).thenReturn(lock);
+      when(lock.tryLock(0, 600000, TimeUnit.MILLISECONDS)).thenReturn(true);
+
+      assertThrows(
+          RuntimeException.class,
+          () ->
+              template.executeWithLock(
+                  "my-key",
+                  () -> {
+                    throw new RuntimeException("Test error");
+                  }));
+
+      verify(lock).unlock();
+    }
+
+    @Test
+    @DisplayName("Should return null when interrupted")
+    void shouldReturnNullWhenInterrupted() throws Exception {
+      when(redissonClient.getLock("lock:my-key")).thenReturn(lock);
+      when(lock.tryLock(anyLong(), anyLong(), eq(TimeUnit.MILLISECONDS)))
+          .thenThrow(new InterruptedException());
+
+      String result = template.executeWithLock("my-key", () -> "result");
+
+      assertNull(result);
+      assertTrue(Thread.currentThread().isInterrupted());
+      Thread.interrupted(); // Clear interrupt status
+    }
+
+    @Test
+    @DisplayName("Should handle IllegalMonitorStateException during unlock")
+    void shouldHandleIllegalMonitorStateExceptionInExecuteWithLock() throws Exception {
+      when(redissonClient.getLock("lock:my-key")).thenReturn(lock);
+      when(lock.tryLock(0, 600000, TimeUnit.MILLISECONDS)).thenReturn(true);
+      doThrow(new IllegalMonitorStateException("Expired")).when(lock).unlock();
+
+      String result = template.executeWithLock("my-key", () -> "result");
+
+      assertEquals("result", result);
+    }
+  }
+
+  @Nested
+  @DisplayName("Builder execute Tests")
+  class BuilderExecuteTests {
+
+    @Test
+    @DisplayName("Should use custom wait time in execute via builder")
+    void shouldUseCustomWaitTimeInExecute() throws Exception {
+      when(redissonClient.getLock("lock:my-key")).thenReturn(lock);
+      when(lock.tryLock(5000, 600000, TimeUnit.MILLISECONDS)).thenReturn(true);
+
+      template.forKey("my-key").waitTime(Duration.ofSeconds(5)).execute(() -> "result");
+
+      verify(lock).tryLock(5000, 600000, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    @DisplayName("Should use custom lease time in execute via builder")
+    void shouldUseCustomLeaseTimeInExecute() throws Exception {
+      when(redissonClient.getLock("lock:my-key")).thenReturn(lock);
+      when(lock.tryLock(0, 30000, TimeUnit.MILLISECONDS)).thenReturn(true);
+
+      template.forKey("my-key").leaseTime(Duration.ofSeconds(30)).execute(() -> "result");
+
+      verify(lock).tryLock(0, 30000, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    @DisplayName("Should use lock type in execute via builder")
+    void shouldUseLockTypeInExecute() throws Exception {
+      RReadWriteLock readWriteLock = mock(RReadWriteLock.class);
+      RLock writeLock = mock(RLock.class);
+      when(redissonClient.getReadWriteLock("lock:my-key")).thenReturn(readWriteLock);
+      when(readWriteLock.writeLock()).thenReturn(writeLock);
+      when(writeLock.tryLock(0, 600000, TimeUnit.MILLISECONDS)).thenReturn(true);
+
+      template.forKey("my-key").lockType(LockType.WRITE).execute(() -> "result");
+
+      verify(readWriteLock).writeLock();
+      verify(writeLock).unlock();
+    }
+
+    @Test
+    @DisplayName("Should use autoRenew in execute via builder")
+    void shouldUseAutoRenewInExecute() throws Exception {
+      when(redissonClient.getLock("lock:my-key")).thenReturn(lock);
+      when(lock.tryLock(0, -1, TimeUnit.MILLISECONDS)).thenReturn(true);
+
+      template.forKey("my-key").autoRenew().execute(() -> "result");
+
+      verify(lock).tryLock(0, -1, TimeUnit.MILLISECONDS);
+    }
+  }
+
+  @Nested
+  @DisplayName("Key Prefix Tests")
+  class KeyPrefixTests {
+
+    @Test
+    @DisplayName("Should apply key prefix")
+    void shouldApplyKeyPrefix() throws InterruptedException {
+      when(redissonClient.getLock("lock:custom-key")).thenReturn(lock);
+      when(lock.tryLock(anyLong(), anyLong(), eq(TimeUnit.MILLISECONDS))).thenReturn(true);
+
+      template.tryLock("custom-key");
+
+      verify(redissonClient).getLock("lock:custom-key");
+    }
+
+    @Test
+    @DisplayName("Should apply custom key prefix")
+    void shouldApplyCustomKeyPrefix() throws InterruptedException {
+      LocksmithProperties customProperties =
+          new LocksmithProperties(
+              new LocksmithProperties.LockProperties(
+                  Duration.ofMinutes(10), Duration.ofSeconds(60), "myapp:", false),
+              null);
+      LocksmithLockTemplate customTemplate =
+          new LocksmithLockTemplate(redissonClient, customProperties);
+
+      when(redissonClient.getLock("myapp:custom-key")).thenReturn(lock);
+      when(lock.tryLock(anyLong(), anyLong(), eq(TimeUnit.MILLISECONDS))).thenReturn(true);
+
+      customTemplate.tryLock("custom-key");
+
+      verify(redissonClient).getLock("myapp:custom-key");
+    }
+  }
+}

--- a/src/test/java/in/riido/locksmith/template/LocksmithSemaphoreTemplateTest.java
+++ b/src/test/java/in/riido/locksmith/template/LocksmithSemaphoreTemplateTest.java
@@ -1,0 +1,395 @@
+package in.riido.locksmith.template;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import in.riido.locksmith.autoconfigure.LocksmithProperties;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.redisson.api.RBucket;
+import org.redisson.api.RPermitExpirableSemaphore;
+import org.redisson.api.RedissonClient;
+
+@DisplayName("LocksmithSemaphoreTemplate Tests")
+class LocksmithSemaphoreTemplateTest {
+
+  private RedissonClient redissonClient;
+  private LocksmithSemaphoreTemplate template;
+  private RPermitExpirableSemaphore semaphore;
+  private RBucket<Integer> metaBucket;
+
+  @BeforeEach
+  @SuppressWarnings("unchecked")
+  void setUp() {
+    redissonClient = mock(RedissonClient.class);
+    LocksmithProperties properties =
+        new LocksmithProperties(
+            null,
+            new LocksmithProperties.SemaphoreProperties(
+                Duration.ofMinutes(5), Duration.ofSeconds(60), "semaphore:", false));
+    template = new LocksmithSemaphoreTemplate(redissonClient, properties);
+    semaphore = mock(RPermitExpirableSemaphore.class);
+    metaBucket = mock(RBucket.class);
+    final var keys = redissonClient.getKeys();
+    if (keys != null && keys.count() > 0) {
+      keys.flushall();
+    }
+  }
+
+  private void setupSemaphore(String key) {
+    when(redissonClient.getPermitExpirableSemaphore("semaphore:" + key)).thenReturn(semaphore);
+    when(redissonClient.<Integer>getBucket("semaphore:" + key + ":meta")).thenReturn(metaBucket);
+    when(metaBucket.get()).thenReturn(null);
+    when(semaphore.trySetPermits(anyInt())).thenReturn(true);
+  }
+
+  @Nested
+  @DisplayName("Simple tryAcquirePermit Tests")
+  class SimpleTryAcquirePermitTests {
+
+    @Test
+    @DisplayName("Should acquire permit immediately with default parameters")
+    void shouldAcquirePermitImmediately() throws InterruptedException {
+      setupSemaphore("my-key");
+      when(semaphore.tryAcquire(0, 300000, TimeUnit.MILLISECONDS)).thenReturn("permit-123");
+
+      String permitId = template.tryAcquirePermit("my-key", 5);
+
+      assertEquals("permit-123", permitId);
+      verify(semaphore).trySetPermits(5);
+      verify(metaBucket).set(5);
+    }
+
+    @Test
+    @DisplayName("Should return null when permit not acquired")
+    void shouldReturnNullWhenPermitNotAcquired() throws InterruptedException {
+      setupSemaphore("my-key");
+      when(semaphore.tryAcquire(0, 300000, TimeUnit.MILLISECONDS)).thenReturn(null);
+
+      String permitId = template.tryAcquirePermit("my-key", 5);
+
+      assertNull(permitId);
+    }
+
+    @Test
+    @DisplayName("Should throw exception for non-positive permits")
+    void shouldThrowExceptionForNonPositivePermits() {
+      assertThrows(IllegalArgumentException.class, () -> template.tryAcquirePermit("my-key", 0));
+
+      assertThrows(IllegalArgumentException.class, () -> template.tryAcquirePermit("my-key", -1));
+    }
+
+    @Test
+    @DisplayName("Should return null when interrupted")
+    void shouldReturnNullWhenInterrupted() throws InterruptedException {
+      setupSemaphore("my-key");
+      when(semaphore.tryAcquire(anyLong(), anyLong(), eq(TimeUnit.MILLISECONDS)))
+          .thenThrow(new InterruptedException());
+
+      String permitId = template.tryAcquirePermit("my-key", 5);
+
+      assertNull(permitId);
+      assertTrue(Thread.currentThread().isInterrupted());
+      Thread.interrupted(); // Clear interrupt status
+    }
+  }
+
+  @Nested
+  @DisplayName("Builder tryAcquire Tests")
+  class BuilderTryAcquireTests {
+
+    @Test
+    @DisplayName("Should use custom wait time via builder")
+    void shouldUseCustomWaitTime() throws InterruptedException {
+      setupSemaphore("my-key");
+      when(semaphore.tryAcquire(5000, 300000, TimeUnit.MILLISECONDS)).thenReturn("permit-123");
+
+      String permitId = template.forKey("my-key", 5).waitTime(Duration.ofSeconds(5)).tryAcquire();
+
+      assertEquals("permit-123", permitId);
+      verify(semaphore).tryAcquire(5000, 300000, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    @DisplayName("Should use custom lease time via builder")
+    void shouldUseCustomLeaseTime() throws InterruptedException {
+      setupSemaphore("my-key");
+      when(semaphore.tryAcquire(0, 60000, TimeUnit.MILLISECONDS)).thenReturn("permit-123");
+
+      String permitId = template.forKey("my-key", 5).leaseTime(Duration.ofMinutes(1)).tryAcquire();
+
+      assertEquals("permit-123", permitId);
+      verify(semaphore).tryAcquire(0, 60000, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    @DisplayName("Should use custom wait and lease time via builder")
+    void shouldUseCustomWaitAndLeaseTime() throws InterruptedException {
+      setupSemaphore("my-key");
+      when(semaphore.tryAcquire(10000, 120000, TimeUnit.MILLISECONDS)).thenReturn("permit-123");
+
+      String permitId =
+          template
+              .forKey("my-key", 5)
+              .waitTime(Duration.ofSeconds(10))
+              .leaseTime(Duration.ofMinutes(2))
+              .tryAcquire();
+
+      assertEquals("permit-123", permitId);
+      verify(semaphore).tryAcquire(10000, 120000, TimeUnit.MILLISECONDS);
+    }
+  }
+
+  @Nested
+  @DisplayName("releasePermit Tests")
+  class ReleasePermitTests {
+
+    @Test
+    @DisplayName("Should release permit")
+    void shouldReleasePermit() {
+      when(redissonClient.getPermitExpirableSemaphore("semaphore:my-key")).thenReturn(semaphore);
+
+      template.releasePermit("my-key", "permit-123");
+
+      verify(semaphore).release("permit-123");
+    }
+
+    @Test
+    @DisplayName("Should handle IllegalArgumentException gracefully")
+    void shouldHandleIllegalArgumentException() {
+      when(redissonClient.getPermitExpirableSemaphore("semaphore:my-key")).thenReturn(semaphore);
+      doThrow(new IllegalArgumentException("Permit expired")).when(semaphore).release("permit-123");
+
+      // Should not throw
+      assertDoesNotThrow(() -> template.releasePermit("my-key", "permit-123"));
+    }
+
+    @Test
+    @DisplayName("Should handle other exceptions gracefully")
+    void shouldHandleOtherExceptionsGracefully() {
+      when(redissonClient.getPermitExpirableSemaphore("semaphore:my-key")).thenReturn(semaphore);
+      doThrow(new RuntimeException("Redis error")).when(semaphore).release("permit-123");
+
+      // Should not throw
+      assertDoesNotThrow(() -> template.releasePermit("my-key", "permit-123"));
+    }
+  }
+
+  @Nested
+  @DisplayName("Simple executeWithPermit Tests")
+  class SimpleExecuteWithPermitTests {
+
+    @Test
+    @DisplayName("Should execute callback when permit acquired")
+    void shouldExecuteCallbackWhenPermitAcquired() throws Exception {
+      setupSemaphore("my-key");
+      when(semaphore.tryAcquire(0, 300000, TimeUnit.MILLISECONDS)).thenReturn("permit-123");
+
+      String result = template.executeWithPermit("my-key", 5, () -> "result");
+
+      assertEquals("result", result);
+      verify(semaphore).release("permit-123");
+    }
+
+    @Test
+    @DisplayName("Should return null when permit not acquired")
+    void shouldReturnNullWhenPermitNotAcquired() throws Exception {
+      setupSemaphore("my-key");
+      when(semaphore.tryAcquire(0, 300000, TimeUnit.MILLISECONDS)).thenReturn(null);
+
+      String result = template.executeWithPermit("my-key", 5, () -> "result");
+
+      assertNull(result);
+      verify(semaphore, never()).release(anyString());
+    }
+
+    @Test
+    @DisplayName("Should release permit even when callback throws exception")
+    void shouldReleasePermitWhenCallbackThrows() throws InterruptedException {
+      setupSemaphore("my-key");
+      when(semaphore.tryAcquire(0, 300000, TimeUnit.MILLISECONDS)).thenReturn("permit-123");
+
+      assertThrows(
+          RuntimeException.class,
+          () ->
+              template.executeWithPermit(
+                  "my-key",
+                  5,
+                  () -> {
+                    throw new RuntimeException("Test error");
+                  }));
+
+      verify(semaphore).release("permit-123");
+    }
+
+    @Test
+    @DisplayName("Should throw exception for non-positive permits in executeWithPermit")
+    void shouldThrowExceptionForNonPositivePermitsInExecuteWithPermit() {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> template.executeWithPermit("my-key", 0, () -> "result"));
+
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> template.executeWithPermit("my-key", -1, () -> "result"));
+    }
+
+    @Test
+    @DisplayName("Should return null when interrupted")
+    void shouldReturnNullWhenInterrupted() throws Exception {
+      setupSemaphore("my-key");
+      when(semaphore.tryAcquire(anyLong(), anyLong(), eq(TimeUnit.MILLISECONDS)))
+          .thenThrow(new InterruptedException());
+
+      String result = template.executeWithPermit("my-key", 5, () -> "result");
+
+      assertNull(result);
+      assertTrue(Thread.currentThread().isInterrupted());
+      Thread.interrupted(); // Clear interrupt status
+    }
+
+    @Test
+    @DisplayName("Should handle IllegalArgumentException during release in executeWithPermit")
+    void shouldHandleIllegalArgumentExceptionInExecuteWithPermit() throws Exception {
+      setupSemaphore("my-key");
+      when(semaphore.tryAcquire(0, 300000, TimeUnit.MILLISECONDS)).thenReturn("permit-123");
+      doThrow(new IllegalArgumentException("Expired")).when(semaphore).release("permit-123");
+
+      String result = template.executeWithPermit("my-key", 5, () -> "result");
+
+      assertEquals("result", result);
+    }
+  }
+
+  @Nested
+  @DisplayName("Builder execute Tests")
+  class BuilderExecuteTests {
+
+    @Test
+    @DisplayName("Should use custom wait time in execute via builder")
+    void shouldUseCustomWaitTimeInExecute() throws Exception {
+      setupSemaphore("my-key");
+      when(semaphore.tryAcquire(5000, 300000, TimeUnit.MILLISECONDS)).thenReturn("permit-123");
+
+      template.forKey("my-key", 5).waitTime(Duration.ofSeconds(5)).execute(() -> "result");
+
+      verify(semaphore).tryAcquire(5000, 300000, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    @DisplayName("Should use custom lease time in execute via builder")
+    void shouldUseCustomLeaseTimeInExecute() throws Exception {
+      setupSemaphore("my-key");
+      when(semaphore.tryAcquire(0, 60000, TimeUnit.MILLISECONDS)).thenReturn("permit-123");
+
+      template.forKey("my-key", 5).leaseTime(Duration.ofMinutes(1)).execute(() -> "result");
+
+      verify(semaphore).tryAcquire(0, 60000, TimeUnit.MILLISECONDS);
+    }
+  }
+
+  @Nested
+  @DisplayName("Semaphore Initialization Tests")
+  class SemaphoreInitializationTests {
+
+    @Test
+    @DisplayName("Should initialize semaphore with permits")
+    void shouldInitializeSemaphoreWithPermits() throws InterruptedException {
+      setupSemaphore("my-key");
+      when(semaphore.tryAcquire(0, 300000, TimeUnit.MILLISECONDS)).thenReturn("permit-123");
+
+      template.tryAcquirePermit("my-key", 5);
+
+      verify(semaphore).trySetPermits(5);
+      verify(metaBucket).set(5);
+    }
+
+    @Test
+    @DisplayName("Should not reinitialize semaphore on second call")
+    void shouldNotReinitializeSemaphoreOnSecondCall() throws InterruptedException {
+      setupSemaphore("my-key");
+      when(semaphore.tryAcquire(anyLong(), anyLong(), eq(TimeUnit.MILLISECONDS)))
+          .thenReturn("permit-123");
+
+      template.tryAcquirePermit("my-key", 5);
+      template.tryAcquirePermit("my-key", 5);
+
+      verify(semaphore, times(1)).trySetPermits(5);
+    }
+
+    @Test
+    @DisplayName("Should use existing semaphore permits")
+    void shouldUseExistingSemaphorePermits() throws InterruptedException {
+      when(redissonClient.getPermitExpirableSemaphore("semaphore:my-key")).thenReturn(semaphore);
+      when(redissonClient.<Integer>getBucket("semaphore:my-key:meta")).thenReturn(metaBucket);
+      when(metaBucket.get()).thenReturn(10); // Existing value
+      when(semaphore.tryAcquire(0, 300000, TimeUnit.MILLISECONDS)).thenReturn("permit-123");
+
+      template.tryAcquirePermit("my-key", 5);
+
+      verify(semaphore, never()).trySetPermits(anyInt());
+    }
+
+    @Test
+    @DisplayName("Should warn when permit count mismatch with existing semaphore")
+    void shouldWarnWhenPermitCountMismatch() throws InterruptedException {
+      when(redissonClient.getPermitExpirableSemaphore("semaphore:my-key")).thenReturn(semaphore);
+      when(redissonClient.<Integer>getBucket("semaphore:my-key:meta")).thenReturn(metaBucket);
+      when(metaBucket.get()).thenReturn(10); // Different from requested 5
+      when(semaphore.tryAcquire(0, 300000, TimeUnit.MILLISECONDS)).thenReturn("permit-123");
+
+      String permitId = template.tryAcquirePermit("my-key", 5);
+
+      assertNotNull(permitId);
+      verify(semaphore, never()).trySetPermits(anyInt());
+    }
+  }
+
+  @Nested
+  @DisplayName("Key Prefix Tests")
+  class KeyPrefixTests {
+
+    @Test
+    @DisplayName("Should apply key prefix")
+    void shouldApplyKeyPrefix() throws InterruptedException {
+      setupSemaphore("custom-key");
+      when(semaphore.tryAcquire(anyLong(), anyLong(), eq(TimeUnit.MILLISECONDS)))
+          .thenReturn("permit-123");
+
+      template.tryAcquirePermit("custom-key", 5);
+
+      verify(redissonClient, atLeastOnce()).getPermitExpirableSemaphore("semaphore:custom-key");
+    }
+
+    @Test
+    @DisplayName("Should apply custom key prefix")
+    void shouldApplyCustomKeyPrefix() throws InterruptedException {
+      LocksmithProperties customProperties =
+          new LocksmithProperties(
+              null,
+              new LocksmithProperties.SemaphoreProperties(
+                  Duration.ofMinutes(5), Duration.ofSeconds(60), "myapp:", false));
+      LocksmithSemaphoreTemplate customTemplate =
+          new LocksmithSemaphoreTemplate(redissonClient, customProperties);
+
+      when(redissonClient.getPermitExpirableSemaphore("myapp:custom-key")).thenReturn(semaphore);
+      when(redissonClient.<Integer>getBucket("myapp:custom-key:meta")).thenReturn(metaBucket);
+      when(metaBucket.get()).thenReturn(null);
+      when(semaphore.trySetPermits(5)).thenReturn(true);
+      when(semaphore.tryAcquire(anyLong(), anyLong(), eq(TimeUnit.MILLISECONDS)))
+          .thenReturn("permit-123");
+
+      customTemplate.tryAcquirePermit("custom-key", 5);
+
+      verify(redissonClient, atLeastOnce()).getPermitExpirableSemaphore("myapp:custom-key");
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds programmatic API for distributed locks and semaphores, complementing the existing annotation-based approach.

- `LocksmithLockTemplate` - programmatic lock management
- `LocksmithSemaphoreTemplate` - programmatic semaphore management
- Callback patterns for automatic resource cleanup
- Full test coverage with unit and integration tests

## Features

### Lock Template
```java
@Autowired
private LocksmithLockTemplate lockTemplate;

// Try lock with timeout
if (lockTemplate.tryLock("order:" + orderId, Duration.ofSeconds(30))) {
    try {
        processOrder(orderId);
    } finally {
        lockTemplate.unlock("order:" + orderId);
    }
}

// Or with callback (auto-unlock)
lockTemplate.executeWithLock("order:" + orderId, () -> {
    processOrder(orderId);
    return result;
});

// Check lock status
boolean locked = lockTemplate.isLocked("resource:" + id);
```

### Semaphore Template
```java
@Autowired
private LocksmithSemaphoreTemplate semaphoreTemplate;

// Acquire permit
if (semaphoreTemplate.tryAcquire("api-pool", Duration.ofSeconds(10))) {
    try {
        callExternalApi();
    } finally {
        semaphoreTemplate.release("api-pool");
    }
}

// Or with callback
semaphoreTemplate.executeWithPermit("api-pool", () -> {
    return callExternalApi();
});
```

## Test plan

- [x] Unit tests for LocksmithLockTemplate
- [x] Unit tests for LocksmithSemaphoreTemplate  
- [x] Integration tests with Redis (Testcontainers)
- [x] All existing tests pass

Closes #40